### PR TITLE
Refactor: Standardize UI components and adjust LoginScreen

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ActionButtonWithFeedback.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ActionButtonWithFeedback.kt
@@ -79,10 +79,23 @@ fun ActionButtonWithFeedback(
         var errorMessage by remember { mutableStateOf<String?>(null) }
         val coroutineScope = rememberCoroutineScope()
 
+        val colorScheme = MaterialTheme.colorScheme
         val (containerColor, contentColor, border) = when (style) {
-            HCButtonStyle.PRIMARY -> Triple(MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.onError, null)
-            HCButtonStyle.SECONDARY -> Triple(MaterialTheme.colorScheme.onError, MaterialTheme.colorScheme.error, BorderStroke(2.dp, MaterialTheme.colorScheme.error))
-            HCButtonStyle.DISABLED -> Triple(Color(0xFFE0E0E0), Color(0xFF9E9E9E), null)
+            HCButtonStyle.PRIMARY -> Triple(
+                colorScheme.primary,
+                colorScheme.onPrimary,
+                null
+            )
+            HCButtonStyle.SECONDARY -> Triple(
+                colorScheme.onPrimary, // Thường là trắng
+                colorScheme.primary,
+                BorderStroke(2.dp, colorScheme.primary)
+            )
+            HCButtonStyle.DISABLED -> Triple(
+                Color(0xFFE0E0E0),
+                Color(0xFF9E9E9E),
+                null
+            )
         }
         val enabled = style != HCButtonStyle.DISABLED && !showLoadingIndicator
 

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/StyledTextField.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/StyledTextField.kt
@@ -3,6 +3,7 @@ package com.sns.homeconnect_v2.presentation.component.widget
 import IoTHomeConnectAppTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -67,12 +68,12 @@ fun StyledTextField(
                 placeholder = {
                     Text(
                         placeholderText,
-                        fontSize = 26.sp,
+                        fontSize = 16.sp,
                         color = if (errorText != null) Color(0xFFD32F2F) else Color(0xFF212121)
                     )
                 },
                 textStyle = androidx.compose.ui.text.TextStyle(
-                    fontSize = 26.sp,
+                    fontSize = 16.sp,
                     color = if (errorText != null) Color(0xFFD32F2F) else Color(0xFF212121)
                 ),
                 shape = RoundedCornerShape(16.dp),
@@ -83,7 +84,7 @@ fun StyledTextField(
                         Icon(
                             imageVector = leadingIcon,
                             contentDescription = null,
-                            modifier = Modifier.size(48.dp),
+                            modifier = Modifier.size(28.dp),
                             tint = Color(0xFF212121)
                         )
                     }
@@ -104,6 +105,7 @@ fun StyledTextField(
                     imeAction = ImeAction.Next
                 ),
                 modifier = Modifier
+                    .height(56.dp)
                     .width(if (isTablet) 500.dp else 400.dp),
                 colors = TextFieldDefaults.colors(
                     focusedTextColor = Color(0xFF212121),
@@ -149,12 +151,12 @@ fun PreviewTextFieldAndDialog() {
             leadingIcon = Icons.Default.Person
         )
     }
-    if (showDialog) {
-        ConfirmationDialog(
-            title = "Xác nhận xoá",
-            message = "Bạn có chắc muốn xoá thiết bị này?",
-            onConfirm = { showDialog = false },
-            onDismiss = { showDialog = false }
-        )
-    }
+//    if (showDialog) {
+//        ConfirmationDialog(
+//            title = "Xác nhận xoá",
+//            message = "Bạn có chắc muốn xoá thiết bị này?",
+//            onConfirm = { showDialog = false },
+//            onDismiss = { showDialog = false }
+//        )
+//    }
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
@@ -35,7 +35,7 @@ fun NavigationGraph(navController: NavHostController) {
 
         // Login screen
         composable(Screens.Login.route) {
-            LoginScreen(navController)
+//            LoginScreen(navController)
         }
 
         // Recover password screen

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/auth/LoginScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/auth/LoginScreen.kt
@@ -4,8 +4,6 @@ import IoTHomeConnectAppTheme
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -13,22 +11,24 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.*
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
 import com.sns.homeconnect_v2.core.util.validation.ValidationUtils
-import com.sns.homeconnect_v2.presentation.viewmodel.auth.LoginUiState
-import com.sns.homeconnect_v2.presentation.viewmodel.auth.LoginViewModel
+import com.sns.homeconnect_v2.presentation.component.widget.ActionButtonWithFeedback
+import com.sns.homeconnect_v2.presentation.component.widget.HCButtonStyle
+import com.sns.homeconnect_v2.presentation.component.widget.StyledTextField
 import com.sns.homeconnect_v2.presentation.navigation.Screens
 
 @Composable
 fun LoginScreen(
     navController: NavHostController,
-    viewModel: LoginViewModel = hiltViewModel()
+//    viewModel: LoginViewModel = hiltViewModel()
 ) {
     IoTHomeConnectAppTheme {
         val configuration = LocalConfiguration.current
@@ -36,10 +36,10 @@ fun LoginScreen(
         val colorScheme = MaterialTheme.colorScheme
         val emailState = remember { mutableStateOf("0306221391@caothang.edu.vn") }
         val passwordState = remember { mutableStateOf("Tu@n1234") }
-        var passwordVisible by remember { mutableStateOf(false) }
+//        var passwordVisible by remember { mutableStateOf(false) }
         val emailErrorState = remember { mutableStateOf("") }
         val passwordErrorState = remember { mutableStateOf("") }
-        val loginUiState by viewModel.loginState.collectAsState()
+//        val loginUiState by viewModel.loginState.collectAsState()
 
         Scaffold(
             modifier = Modifier.fillMaxSize().background(colorScheme.background),
@@ -67,119 +67,71 @@ fun LoginScreen(
                     color = colorScheme.onBackground.copy(alpha = 0.6f)
                 )
 
-                OutlinedTextField(
-                    shape = RoundedCornerShape(25),
-                    singleLine = true,
+                StyledTextField(
                     value = emailState.value,
                     onValueChange = {
                         emailState.value = it
                         emailErrorState.value = ValidationUtils.validateEmail(it)
                     },
-                    placeholder = { Text("Nhập email của bạn") },
-                    leadingIcon = { Icon(Icons.Filled.Email, contentDescription = null) },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Email,
-                        imeAction = ImeAction.Done
-                    ),
-                    modifier = Modifier
-                        .width(if (isTablet) 500.dp else 400.dp)
-                        .height(if (isTablet) 80.dp else 70.dp),
-                    colors = TextFieldDefaults.colors(
-                        focusedTextColor = colorScheme.onBackground,
-                        unfocusedTextColor = colorScheme.onBackground.copy(alpha = 0.7f),
-                        focusedContainerColor = colorScheme.onPrimary,
-                        unfocusedContainerColor = colorScheme.onPrimary,
-                        focusedIndicatorColor = colorScheme.primary,
-                        unfocusedIndicatorColor = colorScheme.onBackground.copy(alpha = 0.5f)
-                    )
+                    placeholderText = "Mật khẩu",
+                    leadingIcon = Icons.Default.Email
                 )
 
-                OutlinedTextField(
-                    shape = RoundedCornerShape(25),
-                    singleLine = true,
+                StyledTextField(
                     value = passwordState.value,
                     onValueChange = {
                         passwordState.value = it
                         passwordErrorState.value = ValidationUtils.validatePassword(it)
                     },
-                    placeholder = { Text("Mật khẩu") },
-                    leadingIcon = { Icon(Icons.Filled.Lock, contentDescription = null) },
-                    trailingIcon = {
-                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
-                            Icon(
-                                imageVector = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff,
-                                contentDescription = if (passwordVisible) "Hide password" else "Show password"
-                            )
-                        }
-                    },
-                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-                    modifier = Modifier
-                        .width(if (isTablet) 500.dp else 400.dp)
-                        .height(if (isTablet) 80.dp else 70.dp),
-                    colors = TextFieldDefaults.colors(
-                        focusedTextColor = colorScheme.onBackground,
-                        unfocusedTextColor = colorScheme.onBackground.copy(alpha = 0.7f),
-                        focusedContainerColor = colorScheme.onPrimary,
-                        unfocusedContainerColor = colorScheme.onPrimary,
-                        focusedIndicatorColor = colorScheme.primary,
-                        unfocusedIndicatorColor = colorScheme.onBackground.copy(alpha = 0.5f)
-                    )
+                    placeholderText = "Mật khẩu",
+                    leadingIcon = Icons.Default.Password,
+                    isPassword = true
                 )
 
                 Row(
                     modifier = Modifier
-                        .width(if (isTablet) 500.dp else 400.dp)
-                        .height(if (isTablet) 80.dp else 70.dp),
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+                        .fillMaxWidth(), // Bắt buộc phải dùng fillMaxWidth
+                    horizontalArrangement = Arrangement.End
                 ) {
-                    Spacer(modifier = Modifier.weight(1f))
                     TextButton(
-                        modifier = Modifier.weight(1f),
-                        onClick = { navController.navigate(Screens.RecoverPassword.route) }
+                        onClick = { /* TODO */ },
+                        contentPadding = PaddingValues(0.dp) // Không bị thụt vào trong
                     ) {
                         Text(
                             text = "Quên mật khẩu?",
-                            fontSize = 14.sp,
-                            color = colorScheme.primary
+                            color = Color(0xFF2979FF), // Hoặc colorScheme.primary
+                            fontWeight = FontWeight.Medium
                         )
                     }
                 }
 
-                Button(
-                    onClick = { viewModel.login(emailState.value, passwordState.value) },
-                    modifier = Modifier
-                        .width(if (isTablet) 300.dp else 200.dp)
-                        .height(if (isTablet) 56.dp else 48.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary),
-                    shape = RoundedCornerShape(50)
-                ) {
-                    Text(
-                        text = "Đăng nhập",
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = colorScheme.onPrimary
-                    )
-                }
 
-                when (loginUiState) {
-                    is LoginUiState.Idle -> {}
-                    is LoginUiState.Loading -> {}
-                    is LoginUiState.Success -> {
-                        LaunchedEffect(Unit) {
-                            navController.navigate("home_graph") {
-                                popUpTo(Screens.Welcome.route) { inclusive = true }
-                            }
-                        }
+                ActionButtonWithFeedback(
+                    label = "Đăng nhập",
+                    style = HCButtonStyle.PRIMARY,
+                    onAction = { _, _ ->
+//                        viewModel.login(emailState.value, passwordState.value)
                     }
-                    is LoginUiState.Error -> {
-                        Text(
-                            text = (loginUiState as LoginUiState.Error).message,
-                            color = colorScheme.error
-                        )
-                    }
-                }
+                )
+
+
+//                when (loginUiState) {
+//                    is LoginUiState.Idle -> {}
+//                    is LoginUiState.Loading -> {}
+//                    is LoginUiState.Success -> {
+//                        LaunchedEffect(Unit) {
+//                            navController.navigate("home_graph") {
+//                                popUpTo(Screens.Welcome.route) { inclusive = true }
+//                            }
+//                        }
+//                    }
+//                    is LoginUiState.Error -> {
+//                        Text(
+//                            text = (loginUiState as LoginUiState.Error).message,
+//                            color = colorScheme.error
+//                        )
+//                    }
+//                }
 
                 Row(
                     modifier = Modifier.fillMaxWidth(if (isTablet) 0.8f else 0.9f),
@@ -204,4 +156,10 @@ fun LoginScreen(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun LoginScreenPreview() {
+    LoginScreen(navController = rememberNavController())
 }


### PR DESCRIPTION
This commit refactors several UI components for better consistency and updates the `LoginScreen`.

Key changes:

- **`ActionButtonWithFeedback.kt`:**
    - Updated `containerColor` and `contentColor` for `PRIMARY` and `SECONDARY` styles to use `MaterialTheme.colorScheme.primary` and `MaterialTheme.colorScheme.onPrimary`.
- **`StyledTextField.kt`:**
    - Reduced `fontSize` of placeholder and input text from `26.sp` to `16.sp`.
    - Reduced `size` of `leadingIcon` from `48.dp` to `28.dp`.
    - Set a fixed `height` of `56.dp` for the `StyledTextField` modifier.
    - Commented out the `ConfirmationDialog` preview code.
- **`LoginScreen.kt`:**
    - Commented out the `LoginViewModel` usage and the related state handling (`loginUiState`).
    - Replaced `OutlinedTextField` with the refactored `StyledTextField` for email and password inputs.
    - Adjusted the "Quên mật khẩu?" `TextButton` to align to the end and remove default padding.
    - Replaced the standard `Button` with `ActionButtonWithFeedback` for the login action.
    - Added a `@Preview` composable for `LoginScreen`.
- **`NavigationGraph.kt`:**
    - Commented out the `LoginScreen` composable call within the navigation graph.

#61