### PR TITLE
feat(space): Implement SpaceScreenViewModel and integrate with HouseD…

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/MainActivity.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/MainActivity.kt
@@ -39,7 +39,7 @@ class MainActivity : ComponentActivity() {
                     // 1. Giao diện chính
                     NavigationGraph(
                         navController = navController,
-                        snackbarViewModel = snackbarViewModel
+                        snackbarViewModel = snackbarViewModel,
                     )
 
                     // 2. Snackbar toàn cục

--- a/app/src/main/java/com/sns/homeconnect_v2/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/di/RepositoryModule.kt
@@ -60,6 +60,7 @@ import com.sns.homeconnect_v2.domain.usecase.weather.GetCurrentWeatherUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.FetchHousesUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.GetHousesByGroupUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.UpdateHouseUseCase
+import com.sns.homeconnect_v2.domain.usecase.space.GetListSpaceUseCase
 import com.sns.homeconnect_v2.domain.usecase.user_activity.GetUserActivitiesUseCase
 import dagger.Binds
 import dagger.Module
@@ -267,6 +268,12 @@ abstract class RepositoryModule {
 
         @Provides
         @Singleton
+        fun provideGetHousesByGroupUseCase(spaceRepository: SpaceRepository): GetListSpaceUseCase {
+            return GetListSpaceUseCase(spaceRepository)
+        }
+
+        @Provides
+        @Singleton
         fun provideFetchHousesUseCase(houseRepository: HouseRepository): FetchHousesUseCase {
             return FetchHousesUseCase(houseRepository)
         }
@@ -351,11 +358,6 @@ abstract class RepositoryModule {
             return GetGroupMembersUseCase(repository)
         }
 
-        @Provides
-        @Singleton
-        fun provideGetHousesByGroupUseCase( houseRepository: HouseRepository): GetHousesByGroupUseCase {
-            return GetHousesByGroupUseCase(houseRepository)
-        }
 
         @Provides
         @Singleton

--- a/app/src/main/java/com/sns/homeconnect_v2/core/util/validation/HouseWithSpacesResponse.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/util/validation/HouseWithSpacesResponse.kt
@@ -7,7 +7,7 @@ fun HouseWithSpacesResponse.toHouseUi(role: String): HouseUi {
     return HouseUi(
         id         = house_id,
         name       = house_name,
-        spaces     = spaces.size,
+        spaces     = spaces?.size ?:0,
         role       = role,
         isRevealed = false,
         icon       = getIconByName(icon_name),

--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -47,6 +47,7 @@ import com.sns.homeconnect_v2.data.remote.dto.request.RecoveryPasswordRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.UpdateGroupMemberRoleRequest
 import com.sns.homeconnect_v2.data.remote.dto.response.CheckEmailResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.ForgotPasswordResponse
+import com.sns.homeconnect_v2.data.remote.dto.response.Space
 import com.sns.homeconnect_v2.data.remote.dto.response.UpdateGroupMemberRoleResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.house.CreateHouseResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.house.HouseResponse
@@ -341,11 +342,11 @@ interface ApiService {
 //    ): WeeklyAverageSensorResponse
 
 
-//    @GET("spaces/{houseId}")
-//    suspend fun getSpaces(
-//        @Path("houseId") houseId: Int,
-//        @Header("Authorization") token: String
-//    ): List<SpaceResponse2>
+    @GET("spaces/house/{houseId}")
+    suspend fun getSpaces(
+        @Path("houseId") houseId: Int,
+        @Header("Authorization") token: String
+    ): List<SpaceResponse>
 //
 //    @PUT("spaces/{id}")
 //    suspend fun updateSpace(

--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/response/Space.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/response/Space.kt
@@ -1,9 +1,14 @@
 package com.sns.homeconnect_v2.data.remote.dto.response
 
-import com.sns.homeconnect_v2.data.remote.dto.base.ISpaceBase
-
 data class Space(
-    override val spaceId: Int,
-    override val name: String,
-    override val houseId: Int
-) : ISpaceBase
+    val spaceId: Int,
+    val houseId: Int,
+    val createdAt: String,
+    val updatedAt: String,
+    val isDeleted: Boolean?,
+    val spaceName: String,
+    val iconColor: String?,
+    val iconName: String?,
+    val spaceDescription: String?,
+    val isRevealed: Boolean = false
+)

--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/response/SpaceResponse.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/response/SpaceResponse.kt
@@ -2,5 +2,13 @@ package com.sns.homeconnect_v2.data.remote.dto.response
 
 data class SpaceResponse(
     val space_id: Int,
-    val space_name: String
+    val house_id: Int,
+    val created_at: String,
+    val updated_at: String,
+    val is_deleted: Boolean?,
+    val space_name: String?,
+    val icon_color: String?,
+    val icon_name: String?,
+    val space_description: String?,
+    val isRevealed: Boolean = false
 )

--- a/app/src/main/java/com/sns/homeconnect_v2/data/repository/SpaceRepositoryImpl.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/repository/SpaceRepositoryImpl.kt
@@ -13,7 +13,7 @@ class SpaceRepositoryImpl @Inject constructor(
 ) : SpaceRepository {
     override suspend fun getSpacesByHomeId(homeId: Int): List<SpaceResponse> {
         val token = authManager.getJwtToken()
-        return apiService.getSpacesByHomeId(homeId, token = "Bearer $token")
+        return apiService.getSpaces(homeId, token = "Bearer $token")
     }
 
     override suspend fun getDevicesBySpaceId(spaceId: Int): List<DeviceResponse> {

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/space/ListSpaceUseCase.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/space/ListSpaceUseCase.kt
@@ -1,0 +1,20 @@
+package com.sns.homeconnect_v2.domain.usecase.space
+
+import com.sns.homeconnect_v2.data.remote.dto.response.SpaceResponse
+import com.sns.homeconnect_v2.domain.repository.SpaceRepository
+import jakarta.inject.Inject
+
+class GetListSpaceUseCase @Inject constructor(
+private val spaceRepository: SpaceRepository
+) {
+    suspend operator fun invoke(
+        houseId: Int
+    ): Result<List<SpaceResponse>> {
+        return try {
+           var response= spaceRepository.getSpacesByHomeId(houseId)
+            Result.success(response)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/HouseCardSwipeable.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/HouseCardSwipeable.kt
@@ -2,9 +2,9 @@ package com.sns.homeconnect_v2.presentation.component
 
 import android.util.Log
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Castle
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Home
@@ -49,7 +49,8 @@ fun HouseCardSwipeable(
     onExpandOnly: () -> Unit,
     onCollapse: () -> Unit,
     onDelete: () -> Unit,
-    onEdit: () -> Unit
+    onEdit: () -> Unit,
+    onClick: () -> Unit
 ){
     Log.d("HouseCardSwipeable", "role: $role, isRevealed: $isRevealed")
     val canEdit = hasPermission(role, RoleLevel.VICE)
@@ -80,6 +81,7 @@ fun HouseCardSwipeable(
             modifier = Modifier
                 .background(color = Color(0xFFD8E4E8))
                 .fillMaxWidth()
+                .clickable { onClick() }
                 .padding(16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
@@ -2,6 +2,7 @@ package com.sns.homeconnect_v2.presentation.navigation
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -30,6 +31,7 @@ import com.sns.homeconnect_v2.presentation.screen.group.GroupScreen
 import com.sns.homeconnect_v2.presentation.screen.group.CreateGroupScreen
 import com.sns.homeconnect_v2.presentation.screen.group.DetailGroupScreen
 import com.sns.homeconnect_v2.presentation.screen.group.house.CreateHouseScreen
+import com.sns.homeconnect_v2.presentation.screen.group.house.HouseDetailScreen
 import com.sns.homeconnect_v2.presentation.screen.group.user.AddUserScreen
 import com.sns.homeconnect_v2.presentation.screen.house.HouseSearchScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.DefaultDetailScreen
@@ -40,9 +42,11 @@ import com.sns.homeconnect_v2.presentation.screen.iot_device.SoftwareVersionScre
 import com.sns.homeconnect_v2.presentation.screen.iot_device.ReportLostDeviceScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.TransferOwnershipScreen
 import com.sns.homeconnect_v2.presentation.viewmodel.snackbar.SnackbarViewModel
+import com.sns.homeconnect_v2.presentation.viewmodel.space.SpaceScreenViewModel
 
 @Composable
-fun NavigationGraph(navController: NavHostController, snackbarViewModel: SnackbarViewModel) {
+fun NavigationGraph(navController: NavHostController, snackbarViewModel: SnackbarViewModel,
+                    ) {
     NavHost(navController = navController, startDestination = Screens.Welcome.route) {
         // --- Auth screens ---
         composable(Screens.Welcome.route) {
@@ -193,6 +197,23 @@ fun NavigationGraph(navController: NavHostController, snackbarViewModel: Snackba
                     groupId = groupId
                 )
             }
+
+
+            composable(
+                route = Screens.ListSpace.route,
+                arguments = listOf(navArgument("houseId") { type = NavType.IntType })
+            ) {
+                backStackEntry ->
+                val spaceViewModel: SpaceScreenViewModel= hiltViewModel()
+                val houseId = backStackEntry.arguments?.getInt("houseId") ?: -1
+                HouseDetailScreen(
+                    navController = navController,
+                    snackbarViewModel = snackbarViewModel,
+                    spaceViewModel = spaceViewModel,
+                    houseId = houseId
+                )
+            }
+
             // TODO: Add AddGroupUser screen with route "add_group_user/{groupId}"
 
             composable(

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/Screens.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/Screens.kt
@@ -58,6 +58,10 @@ sealed class Screens(val route: String) {
         fun createRoute(spaceId: Int) = "space_detail/$spaceId"
     }
 
+    data object ListSpace : Screens("list_space/{houseId}") {
+        fun createRoute(houseId: Int) = "list_space/$houseId"
+    }
+
     // --- Group screens ---
     data object Groups : Screens("groups")
     data object CreateGroup : Screens("create_group")

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/DetailGroupScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/DetailGroupScreen.kt
@@ -427,7 +427,15 @@ fun DetailGroupScreen(
                                             housesUi.removeAt(index)
                                         },
                                         onEdit = {
-                                            navController.navigate(Screens.EditHouse.createRoute(house.id))
+                                            navController.navigate(
+                                                Screens.EditHouse.createRoute(
+                                                    house.id
+                                                )
+                                            )
+                                        },
+                                        onClick= {
+                                            //chuyển sang danh sách space của house
+                                            navController.navigate(Screens.ListSpace.createRoute(house.id))
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.sns.homeconnect_v2.presentation.screen.group.house
 
 import IoTHomeConnectAppTheme
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -24,6 +25,8 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.google.android.gms.common.util.DeviceProperties.isTablet
+import com.sns.homeconnect_v2.core.util.validation.toColor
+import com.sns.homeconnect_v2.core.util.validation.toIcon
 import com.sns.homeconnect_v2.presentation.component.SpaceCardSwipeable
 import com.sns.homeconnect_v2.presentation.component.navigation.Header
 import com.sns.homeconnect_v2.presentation.component.navigation.MenuBottom
@@ -32,26 +35,39 @@ import com.sns.homeconnect_v2.presentation.component.widget.*
 import com.sns.homeconnect_v2.presentation.model.FabChild
 import com.sns.homeconnect_v2.presentation.model.SpaceUi
 import com.sns.homeconnect_v2.presentation.viewmodel.snackbar.SnackbarViewModel
+import com.sns.homeconnect_v2.presentation.viewmodel.space.SpaceScreenViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
 fun HouseDetailScreen(
     navController: NavHostController,
-    houseIcon: ImageVector,
-    colorIcon: Color,
-    houseName: String,
-    houseAddress: String,
-    snackbarViewModel: SnackbarViewModel = hiltViewModel()
+//    houseIcon: ImageVector,
+//    colorIcon: Color,
+//    houseName: String,
+//    houseAddress: String,
+    snackbarViewModel: SnackbarViewModel = hiltViewModel(),
+    spaceViewModel:SpaceScreenViewModel = hiltViewModel(),
+    houseId:Int
 ) {
+
     val scope = rememberCoroutineScope()
-    val spaces = remember {
-        mutableStateListOf(
-            SpaceUi(1, "Bathroom", 5, false, Icons.Default.BedroomBaby, Color.Blue),
-            SpaceUi(2, "Bedroom", 3, false, Icons.Default.Home, Color.Red),
-            SpaceUi(3, "Lounge", 7, false, Icons.Default.Group, Color.Green)
-        )
+
+
+    LaunchedEffect(Unit) {
+        spaceViewModel.getSpaces(houseId)
     }
+    val spaces by spaceViewModel.spaces.collectAsState()
+    Log.d("spaces", spaces.toString())
+    Log.d("houseId", houseId.toString())
+
+//    val spaces = remember {
+//        mutableStateListOf(
+//            SpaceUi(1, "Bathroom", 5, false, Icons.Default.BedroomBaby, Color.Blue),
+//            SpaceUi(2, "Bedroom", 3, false, Icons.Default.Home, Color.Red),
+//            SpaceUi(3, "Lounge", 7, false, Icons.Default.Group, Color.Green)
+//        )
+//    }
 
     IoTHomeConnectAppTheme {
         val fabOptions = listOf(
@@ -120,14 +136,14 @@ fun HouseDetailScreen(
                             Column(modifier = Modifier.align(Alignment.CenterStart)) {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Icon(
-                                        imageVector = houseIcon,
+                                        imageVector = Icons.Default.Home,
                                         contentDescription = "House Icon",
-                                        tint = colorIcon,
+                                        tint = Color.White,
                                         modifier = Modifier.size(32.dp)
                                     )
                                     Spacer(Modifier.width(8.dp))
                                     Text(
-                                        text = houseName,
+                                        text =  "Nhà của tôi",
                                         color = Color.White,
                                         fontSize = 24.sp,
                                         fontWeight = FontWeight.Bold
@@ -148,7 +164,7 @@ fun HouseDetailScreen(
                                     )
                                     Spacer(Modifier.width(8.dp))
                                     Text(
-                                        text = houseAddress,
+                                        text =  "123 Đường ABC, Quận 1, TP.HCM",
                                         modifier = Modifier.weight(1f),
                                         color = Color.White,
                                         fontSize = 16.sp,
@@ -196,20 +212,20 @@ fun HouseDetailScreen(
                         Spacer(Modifier.height(8.dp))
 
                         SpaceCardSwipeable(
-                            spaceName = space.name,
-                            deviceCount = space.device,
-                            icon = space.icon,
-                            iconColor = space.iconColor,
+                            spaceName = space.space_name?: "không có tên",
+                            deviceCount = space.space_id,
+                            icon = space.icon_name?.toIcon() ?: Icons.Default.Home,
+                            iconColor = space.icon_color?.toColor()?: Color.Gray,
                             isRevealed = space.isRevealed,
                             onExpandOnly = {
                                 spaces.indices.forEach { i ->
-                                    spaces[i] = spaces[i].copy(isRevealed = i == index)
+                                    spaceViewModel.updateRevealState(i)
                                 }
                             },
                             onCollapse = {
-                                spaces[index] = space.copy(isRevealed = false)
+                                spaceViewModel.collapseItem(index)
                             },
-                            onDelete = { spaces.removeAt(index) },
+                            onDelete = {  },
                             onEdit = { /* TODO */ },
                             onClick = { /* TODO */ }
                         )
@@ -240,19 +256,3 @@ fun HouseDetailScreen(
     }
 }
 
-@Preview(
-    name = "Phone – 360 × 800",
-    showBackground = true,
-    widthDp = 360,
-    heightDp = 800
-)
-@Composable
-fun HouseDetailScreenPreview() {
-    HouseDetailScreen(
-        navController = rememberNavController(),
-        houseIcon = Icons.Default.Home,
-        colorIcon = Color.Blue,
-        houseName = "Nhà của tôi",
-        houseAddress = "123 Đường ABC, Quận 1, TP.HCM"
-    )
-}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/house/HouseSearchScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/house/HouseSearchScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +32,7 @@ import com.sns.homeconnect_v2.presentation.component.widget.InvertedCornerHeader
 import com.sns.homeconnect_v2.presentation.component.widget.LabeledBox
 import com.sns.homeconnect_v2.presentation.component.widget.RadialFab
 import com.sns.homeconnect_v2.presentation.model.FabChild
+import com.sns.homeconnect_v2.presentation.navigation.Screens
 import com.sns.homeconnect_v2.presentation.viewmodel.house.HouseSearchViewModel
 
 @Composable
@@ -47,7 +47,7 @@ fun HouseSearchScreen(
     val housesUi = houses.map { it.toHouseUi(role = "member") } //ToDo sau này sửa quyền
 
     LaunchedEffect(Unit) {
-        viewModel.loadHousesByGroup() // mặc định groupId = 5
+        viewModel.loadHousesByGroup(5) // mặc định groupId = 5
     }
 
     Log.d("HouseSearchScreen", "Houses: $houses")
@@ -158,7 +158,10 @@ fun HouseSearchScreen(
                             onExpandOnly = { /* ... */ },
                             onCollapse   = { /* ... */ },
                             onDelete     = { /* ... */ },
-                            onEdit       = { /* ... */ }
+                            onEdit       = { /* ... */ },
+                            onClick = {
+                                //navController.navigate(Screens.HouseDetail.createRoute(house.id))
+                            }
                         )
                     }
                 }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/house/HouseSearchViewModel.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/house/HouseSearchViewModel.kt
@@ -20,7 +20,7 @@ class HouseSearchViewModel @Inject constructor(
     private val _houses = MutableStateFlow<List<HouseWithSpacesResponse>>(emptyList())
     val houses = _houses.asStateFlow()
 
-    fun loadHousesByGroup(groupId: Int = 5) {
+    fun loadHousesByGroup(groupId: Int) {
         viewModelScope.launch {
             _isLoading.value = true
             getHousesByGroupUseCase(groupId).fold(

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/space/SpaceScreenViewModel.k.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/space/SpaceScreenViewModel.k.kt
@@ -1,0 +1,51 @@
+package com.sns.homeconnect_v2.presentation.viewmodel.space
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sns.homeconnect_v2.data.remote.dto.response.Space
+import com.sns.homeconnect_v2.data.remote.dto.response.SpaceResponse
+import com.sns.homeconnect_v2.domain.usecase.space.GetListSpaceUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SpaceScreenViewModel @Inject constructor(
+    private val getListSpaceUseCase: GetListSpaceUseCase,
+) : ViewModel() {
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading = _isLoading.asStateFlow()
+
+    private val _spaces = MutableStateFlow<List<SpaceResponse>>(emptyList())
+    val spaces = _spaces.asStateFlow()
+
+    fun getSpaces(houseId: Int) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = getListSpaceUseCase.invoke(houseId)
+            result.onSuccess { spaces ->
+                _spaces.value = spaces // Đảm bảo spaces là List<Space>
+                Log.d("ViewModel space", spaces.toString())
+            }.onFailure { error ->
+                error.printStackTrace()
+                Log.e("ViewModel error", error.toString())
+            }
+            _isLoading.value = false
+        }
+    }
+    fun updateRevealState(index: Int) {
+        _spaces.value = _spaces.value.mapIndexed { i, item ->
+            item.copy(isRevealed = i == index)
+        }
+    }
+
+    fun collapseItem(index: Int) {
+        _spaces.value = _spaces.value.mapIndexed { i, item ->
+            if (i == index) item.copy(isRevealed = false) else item
+        }
+    }
+}


### PR DESCRIPTION
…etailScreen

This commit introduces `SpaceScreenViewModel` to manage the state and logic for displaying spaces within a house. It also integrates this ViewModel with `HouseDetailScreen` to fetch and display spaces.

Key changes:
- Created `SpaceScreenViewModel.k.kt` with `isLoading` and `spaces` state flows.
- Implemented `getSpaces(houseId)` function in `SpaceScreenViewModel` to fetch spaces using `GetListSpaceUseCase`.
- Added `updateRevealState` and `collapseItem` functions to manage the revealed state of space cards.
- Integrated `SpaceScreenViewModel` into `HouseDetailScreen.kt`.
- `HouseDetailScreen` now fetches spaces using `spaceViewModel.getSpaces(houseId)` in a `LaunchedEffect`.
- `HouseDetailScreen` observes `spaceViewModel.spaces` and updates the UI accordingly.
- Modified `HouseCardSwipeable` in `DetailGroupScreen.kt` and `HouseSearchScreen.kt` to navigate to `Screens.ListSpace` on click, passing the `houseId`.
- Added `ListSpace` screen to `Screens.kt` and `NavigationGraph.kt`.
- Updated `ApiService.kt` to use the correct endpoint `spaces/house/{houseId}` for fetching spaces.
- Updated `SpaceRepositoryImpl.kt` to call the correct `apiService.getSpaces` method.
- Modified `SpaceResponse.kt` and `Space.kt` to align with the API response structure.
- In `HouseWithSpacesResponse.kt`, handled nullable `spaces` by providing a default size of 0.
- In `RepositoryModule.kt`, provided `GetListSpaceUseCase`.
- Updated `HouseSearchViewModel.kt`'s `loadHousesByGroup` to accept `groupId` as a parameter.
- Made `HouseCardSwipeable.kt` clickable to trigger navigation.
- Removed hardcoded data from `HouseDetailScreen` and replaced it with data fetched from the ViewModel.