### PR TITLE
Refactor: Remove LinkDevice functionality from ApiService

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -141,13 +141,6 @@ interface ApiService {
         @Header("Authorization") token: String
     ): UnlinkResponse
   
-   @POST("devices/link")
-    suspend fun linkDevice(
-        @Body body: LinkDeviceRequest,
-        @Header("Authorization") token: String
-    ): LinkDeviceResponse
-  
-  
     @GET("houses/{houseId}")
     suspend fun getHouseId(
         @Path("houseId") houseId: Int,


### PR DESCRIPTION
This commit removes the `linkDevice` endpoint and its associated request/response objects (`LinkDeviceRequest`, `LinkDeviceResponse`) from the `ApiService` interface.