### PR TITLE
Refactor: Clean up unused imports and commented-out code

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/di/RepositoryModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.sns.homeconnect_v2.PermissionEventHandler
 import com.sns.homeconnect_v2.core.permission.PermissionManager
 import com.sns.homeconnect_v2.data.AuthManager
-import com.sns.homeconnect_v2.data.remote.api.EcomApiService
 import com.sns.homeconnect_v2.data.repository.AlertRepositoryImpl
 import com.sns.homeconnect_v2.data.repository.AuthRepositoryImpl
 import com.sns.homeconnect_v2.data.repository.DeviceRepositoryImpl
@@ -41,19 +40,13 @@ import com.sns.homeconnect_v2.domain.usecase.group.CreateGroupUseCase
 import com.sns.homeconnect_v2.domain.usecase.group.DeleteGroupUseCase
 import com.sns.homeconnect_v2.domain.usecase.group.GetGroupMembersUseCase
 import com.sns.homeconnect_v2.domain.usecase.group.GetListHouseByGroupUseCase
-import com.sns.homeconnect_v2.domain.usecase.group.GetMyGroupsUseCase
 import com.sns.homeconnect_v2.domain.usecase.home.FetchSharedWithUseCase
 import com.sns.homeconnect_v2.domain.usecase.home.GetListHouseUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.CreateHouseUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.DeleteHouseUseCase
-import com.sns.homeconnect_v2.domain.usecase.house.FetchHousesUseCase
-import com.sns.homeconnect_v2.domain.usecase.house.GetHouseUseCase
-import com.sns.homeconnect_v2.domain.usecase.house.GetHousesByGroupUseCase
-import com.sns.homeconnect_v2.domain.usecase.house.UpdateHouseUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.AttributeDeviceUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.GetInfoDeviceUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.LinkDeviceUseCase
-import com.sns.homeconnect_v2.domain.usecase.iot_device.ListOfUserOwnedDevicesUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.ToggleDeviceUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.UnlinkDeviceUseCase
 import com.sns.homeconnect_v2.domain.usecase.iot_device.sharing.AddSharedUserUseCase
@@ -70,7 +63,6 @@ import com.sns.homeconnect_v2.domain.usecase.profile.GetInfoProfileUseCase
 import com.sns.homeconnect_v2.domain.usecase.profile.PutInfoProfileUseCase
 import com.sns.homeconnect_v2.domain.usecase.profile.UpdatePasswordUseCase
 import com.sns.homeconnect_v2.domain.usecase.space.DeleteSpaceUseCase
-import com.sns.homeconnect_v2.domain.usecase.weather.GetCurrentWeatherUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.FetchHousesUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.GetHouseUseCase
 import com.sns.homeconnect_v2.domain.usecase.house.UpdateHouseUseCase
@@ -144,7 +136,6 @@ abstract class RepositoryModule {
     abstract fun bindEcomRepository(impl: EcomRepositoryImpl): EcomRepository
 
 
-
     companion object {
         @Provides
         @Singleton
@@ -166,7 +157,10 @@ abstract class RepositoryModule {
 
         @Provides
         @Singleton
-        fun provideLoginUseCase(authRepository: AuthRepository, authManager: AuthManager): LoginUseCase {
+        fun provideLoginUseCase(
+            authRepository: AuthRepository,
+            authManager: AuthManager
+        ): LoginUseCase {
             return LoginUseCase(authRepository, authManager)
         }
 
@@ -296,10 +290,10 @@ abstract class RepositoryModule {
             return GetListSpaceUseCase(spaceRepository)
         }
 
-        @Provides
-        @Singleton
-        fun provideGetSpaceDetailUseCase(spaceRepository: SpaceRepository): GetSpaceDetailUseCase {
-          
+//        @Provides
+//        @Singleton
+//        fun provideGetSpaceDetailUseCase(spaceRepository: SpaceRepository): GetSpaceDetailUseCase {}
+
         @Provides
         @Singleton
         fun provideUpdateSpaceUseCase(spaceRepository: SpaceRepository): UpdateSpaceUseCase {

--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -1,6 +1,5 @@
 package com.sns.homeconnect_v2.data.remote.api
 
-import androidx.compose.ui.semantics.Role
 import com.sns.homeconnect_v2.data.remote.dto.base.ApiResponse
 import com.sns.homeconnect_v2.data.remote.dto.base.CreateGroupResponse
 import com.sns.homeconnect_v2.data.remote.dto.request.AddGroupMemberRequest
@@ -45,23 +44,19 @@ import com.sns.homeconnect_v2.data.remote.dto.response.UserActivityResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.UserGroupResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.UserResponse
 import com.sns.homeconnect_v2.data.remote.dto.request.CreateHouseRequest
-import com.sns.homeconnect_v2.data.remote.dto.request.CreateSpaceRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.DeviceCapabilitiesRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.RecoveryPasswordRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.UpdateDeviceStateRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.UpdateGroupMemberRoleRequest
 import com.sns.homeconnect_v2.data.remote.dto.request.UpdateSpaceRequest
 import com.sns.homeconnect_v2.data.remote.dto.response.CheckEmailResponse
-import com.sns.homeconnect_v2.data.remote.dto.response.CreateSpaceResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.BulkDeviceStateUpdateResponse
-import com.sns.homeconnect_v2.data.remote.dto.response.CheckEmailResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.DeviceCapabilitiesResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.DeviceResponseSpace
 import com.sns.homeconnect_v2.data.remote.dto.response.DeviceStateResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.ForgotPasswordResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.OwnedDeviceResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.RoleResponse
-import com.sns.homeconnect_v2.data.remote.dto.response.Space
 import com.sns.homeconnect_v2.data.remote.dto.response.UpdateDeviceStateResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.UpdateGroupMemberRoleResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.house.CreateHouseResponse
@@ -70,7 +65,6 @@ import com.sns.homeconnect_v2.data.remote.dto.response.house.HouseResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.house.HousesListResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.house.UpdateHouseRequest
 import com.sns.homeconnect_v2.data.remote.dto.response.house.UpdateHouseResponse
-import com.sns.homeconnect_v2.presentation.navigation.Screens
 import retrofit2.Response
 import retrofit2.http.*
 
@@ -160,11 +154,11 @@ interface ApiService {
         @Header("Authorization") token: String
     ): House
 
-    @GET("spaces/{homeId}")
-    suspend fun getSpacesByHomeId(
-        @Path("homeId") homeId: Int,
-        @Header("Authorization") token: String
-    ): House
+//    @GET("spaces/{homeId}")
+//    suspend fun getSpacesByHomeId(
+//        @Path("homeId") homeId: Int,
+//        @Header("Authorization") token: String
+//    ): House
 
     @GET("devices/space/{spaceId}")
     suspend fun getDevicesBySpaceId(
@@ -305,10 +299,10 @@ interface ApiService {
     @POST("notifications/otp")
     suspend fun sendOtp(@Body request: EmailRequest): EmailResponse
 
-    @POST("otp/verify")
-    suspend fun verifyOTPOld(
-        @Body request: EmailRequest
-    ): EmailResponse
+//    @POST("otp/verify")
+//    suspend fun verifyOTPOld(
+//        @Body request: EmailRequest
+//    ): EmailResponse
 
     @POST("notifications/otp/verify")
     suspend fun verifyOTPNew(

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
@@ -13,18 +13,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.rememberNavController
-import com.google.android.gms.common.util.DeviceProperties.isTablet
 import com.sns.homeconnect_v2.core.util.validation.SnackbarVariant
 import com.sns.homeconnect_v2.core.util.validation.toColor
 import com.sns.homeconnect_v2.core.util.validation.toIcon
@@ -32,13 +26,9 @@ import com.sns.homeconnect_v2.presentation.component.BottomSheetWithTrigger
 import com.sns.homeconnect_v2.presentation.component.SpaceCardSwipeable
 import com.sns.homeconnect_v2.presentation.component.navigation.Header
 import com.sns.homeconnect_v2.presentation.component.navigation.MenuBottom
-import com.sns.homeconnect_v2.presentation.component.navigation.MenuItem
 import com.sns.homeconnect_v2.presentation.component.widget.*
 import com.sns.homeconnect_v2.presentation.model.FabChild
-import com.sns.homeconnect_v2.presentation.model.SpaceUi
 import com.sns.homeconnect_v2.presentation.navigation.Screens
-import com.sns.homeconnect_v2.presentation.viewmodel.group.GetRoleViewModel
-import com.sns.homeconnect_v2.presentation.viewmodel.home.HomeScreenViewModel
 import com.sns.homeconnect_v2.presentation.viewmodel.house.GetHouseViewModel
 import com.sns.homeconnect_v2.presentation.viewmodel.snackbar.SnackbarViewModel
 import com.sns.homeconnect_v2.presentation.viewmodel.space.DeleteSpaceViewModel
@@ -60,11 +50,9 @@ fun HouseDetailScreen(
     currentUserRole: String,
 ) {
 
-    val scope = rememberCoroutineScope()
     val deletespace: DeleteSpaceViewModel = hiltViewModel()
     val deteteState by deletespace.deleteState.collectAsState()
     val updateSpaceViewModel: UpdateSpaceViewModel = hiltViewModel()
-    val snackbarViewModel: SnackbarViewModel = hiltViewModel()
 
     val spaceDetail by updateSpaceViewModel.updatespace.collectAsState()
 


### PR DESCRIPTION
This commit removes several unused imports from `ApiService.kt` and `HouseDetailScreen.kt`. It also removes commented-out code blocks related to `getSpacesByHomeId`, `verifyOTPOld` in `ApiService.kt`, and the `provideGetSpaceDetailUseCase` in `RepositoryModule.kt`.