### PR TITLE
Refactor: Enhance Create Space Screen and Color Picker

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/core/util/validation/parseColorOrDefault.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/util/validation/parseColorOrDefault.kt
@@ -14,16 +14,16 @@ fun parseColorOrDefault(hex: String?, fallback: Color = Color.Gray): Color {
 // Extension function để chuyển String sang Color
 fun String.toColor(): Color {
     return when (this.lowercase()) {
-        "blue" -> Color(0xFF2196F3)
-        "red" -> Color(0xFFF44336)
-        "green" -> Color(0xFF4CAF50)
-        "yellow" -> Color(0xFFFFEB3B)
-        "purple" -> Color(0xFF9C27B0)
-        "orange" -> Color(0xFFFF9800)
-        "teal" -> Color(0xFF009688)
-        "pink" -> Color(0xFFE91E63)
-        "cyan" -> Color(0xFF00BCD4)
-        "gray", "grey" -> Color(0xFF9E9E9E)
+        "blue", "#2196F3" -> Color(0xFF2196F3)
+        "red", "#F44336" -> Color(0xFFF44336)
+        "green", "#4CAF50" -> Color(0xFF4CAF50)
+        "yellow", "#FFEB3B" -> Color(0xFFFFEB3B)
+        "purple", "#9C27B0" -> Color(0xFF9C27B0)
+        "orange", "#FF9800" -> Color(0xFFFF9800)
+        "teal", "#009688" -> Color(0xFF009688)
+        "pink", "#E91E63" -> Color(0xFFE91E63)
+        "cyan", "#00BCD4" -> Color(0xFF00BCD4)
+        "gray", "grey", "#9E9E9E" -> Color(0xFF9E9E9E)
         else -> Color(0xFF2196F3) // Default blue
     }
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/data/repository/SpaceRepositoryImpl.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/repository/SpaceRepositoryImpl.kt
@@ -15,58 +15,60 @@ class SpaceRepositoryImpl @Inject constructor(
     private val apiService: ApiService,
     private val authManager: AuthManager
 ) : SpaceRepository {
+    /** Lấy toàn bộ Space thuộc một House */
     override suspend fun getSpacesByHomeId(homeId: Int): List<SpaceResponse> {
-        val token = authManager.getJwtToken()
+        val token = authManager.getJwtToken().orEmpty()
         return apiService.getSpaces(homeId, token = "Bearer $token")
     }
 
+    /** Lấy danh sách Device nằm trong một Space */
     override suspend fun getDevicesBySpaceId(spaceId: Int): List<DeviceResponseSpace> {
-        val token = authManager.getJwtToken()
+        val token = authManager.getJwtToken().orEmpty()
         return apiService.getDevicesBySpaceId(spaceId, token = "Bearer $token")
     }
 
+    /** Tạo Space mới */
     override suspend fun createSpace(request: CreateSpaceRequest): SpaceResponse {
         val token = authManager.getJwtToken()
         Log.d("SpaceRepositoryImpl", "Token: $token")
         return apiService.createSpace(request, token = "Bearer $token")
+    }
 
+    /** Xoá Space */
     override suspend fun deleteSpace(spaceId: Int): Result<Unit> {
-        val token = authManager.getJwtToken()
-        return try {
-            apiService.deleteSpace(spaceId, "Bearer $token")
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        return runCatching {
+            val token = authManager.getJwtToken().orEmpty()
+            apiService.deleteSpace(spaceId, token = "Bearer $token")
         }
     }
+
+    /** Cập nhật Space */
+    override suspend fun updateSpace(
+        spaceId: Int,
+        name: String,
+        iconName: String?,
+        iconColor: String?,
+        description: String?
+    ): Result<SpaceResponse> {
+        val token = authManager.getJwtToken().orEmpty()
+        val body = UpdateSpaceRequest(
+            space_name       = name,
+            icon_name        = iconName,
+            icon_color       = iconColor,
+            space_description = description
+        )
+        return runCatching {
+            apiService.updateSpace(spaceId, body, token = "Bearer $token")
+        }
+    }
+}
 
 //    override suspend fun getSpaces(houseId: Int): List<SpaceResponse2> {
 //        val token = authManager.getJwtToken()
 //        return apiService.getSpaces(houseId, "Bearer $token")
 //    }
 //
-override suspend fun updateSpace(
-    spaceId: Int,
-    name: String,
-    iconName: String?,
-    iconColor: String?,
-    description: String?
-): Result<SpaceResponse> {
-    return try {
-        val token = authManager.getJwtToken() ?: return Result.failure(IllegalStateException("Token không hợp lệ"))
-        val updateSpaceRequest = UpdateSpaceRequest(
-            space_name = name,
-            icon_name = iconName,
-            icon_color = iconColor,
-            space_description = description
-        )
-        val response = apiService.updateSpace(spaceId, updateSpaceRequest, token = "Bearer $token")
-        Result.success(response)
-    } catch (e: Exception) {
-        Result.failure(e)
-    }
-}
-//
+
 //    override suspend fun createSpace(houseId: Int, name: String): CreateSpaceResponse {
 //        val token = authManager.getJwtToken()
 //        val createSpaceRequest = CreateSpaceRequest(HouseID = houseId, Name = name)
@@ -77,4 +79,4 @@ override suspend fun updateSpace(
 //        val token = authManager.getJwtToken()
 //        return apiService.getSpaceDetail(spaceId, "Bearer $token")
 //    }
-}
+//}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ColorPicker.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ColorPicker.kt
@@ -46,16 +46,18 @@ fun ColorPicker(
     onColorSelected: (String) -> Unit
 ) {
     val colors = listOf(
-        Color.Red to "#FF0000",
-        Color.Green to "#00FF00",
-        Color.Blue to "#0000FF",
-        Color.Yellow to "#FFFF00",
-        Color.Cyan to "#00FFFF",
-        Color.Magenta to "#FF00FF",
-        Color.Gray to "#808080",
-        Color.Black to "#000000",
-        Color.White to "#FFFFFF",
-        Color(0xFF2196F3) to "#2196F3"
+        Color(0xFF2196F3) to "blue", // ✅ dùng mã hex
+        Color(0xFFF44336) to "red",
+        Color(0xFF4CAF50) to "green",
+        Color(0xFFFFEB3B) to "yellow",
+        Color(0xFF9C27B0) to "purple",
+        Color(0xFFFF9800) to "orange",
+        Color(0xFF009688) to "teal",
+        Color(0xFFE91E63) to "pink",
+        Color(0xFF00BCD4) to "cyan",
+        Color(0xFF9E9E9E) to "gray",
+        Color(0xFF000000) to "black",
+        Color(0xFFFFFFFF) to "white"
     )
 
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/Screens.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/Screens.kt
@@ -51,9 +51,9 @@ sealed class Screens(val route: String) {
         fun createRoute(houseId: Int) = "create_space/$houseId"
     }
 
-    data object AddSpace : Screens("add_space") {
-        fun createRoute(houseId: Int) = "add_space"
-    }
+//    data object AddSpace : Screens("add_space") {
+//        fun createRoute(houseId: Int) = "add_space"
+//    }
 
     data object EditSpaceWithHouse : Screens("edit_space/{houseId}") {
         fun createRoute(houseId: Int) = "edit_space/$houseId"

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/HouseDetailScreen.kt
@@ -278,6 +278,7 @@ fun HouseDetailScreen(
 
                         updateSpaceViewModel.updateSpace(space.space_id, spaceNameInput, iconNameInput, iconColorInput, descriptionInput)
 
+                        Log.d("SpaceDetail", "Space ID: ${space.space_id}, Name: ${space.space_name}, Icon: ${space.icon_name}, Color: ${space.icon_color}")
                         SpaceCardSwipeable(
                             spaceName = space.space_name?: "không có tên",
                             deviceCount = space.space_id,

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/space/CreateSpaceScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/house/space/CreateSpaceScreen.kt
@@ -20,6 +20,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.google.android.gms.common.util.DeviceProperties.isTablet
 import com.sns.homeconnect_v2.core.util.validation.SnackbarVariant
+import com.sns.homeconnect_v2.core.util.validation.parseColorOrDefault
 import com.sns.homeconnect_v2.data.remote.dto.base.GroupIconCategory
 import com.sns.homeconnect_v2.presentation.component.widget.ColorPicker
 import com.sns.homeconnect_v2.presentation.component.widget.IconPicker
@@ -47,8 +48,6 @@ fun CreateSpaceScreen(
     val isSuccess by viewModel.isSuccess.collectAsState()
 
     var sel by remember { mutableStateOf<String?>(null) }
-    var spaceName by remember { mutableStateOf("") }
-    var selectedRole by remember { mutableStateOf<String?>(null) }
     var selectedIconLabel by remember { mutableStateOf("Nhà") }
     var selectedColorLabel by remember { mutableStateOf("blue") }
 
@@ -197,17 +196,18 @@ fun CreateSpaceScreen(
 
                 item {
                     IconPicker(
-                        category = GroupIconCategory.HOUSE,
+                        category = GroupIconCategory.SPACE,
                         selectedIconName = sel,
                         onIconSelected = { sel = it },
                         modifier = Modifier.padding(16.dp)
                     )
+                    viewModel .updateIconName(sel ?: "home") // Cập nhật iconName nếu sel không null
                     Log.d("CreateSpaceScreen", "iconName: $iconName")
                 }
 
                 item {
                     ColorPicker(
-                        selectedColorLabel = iconColor,
+                        selectedColorLabel =  iconColor,
                         onColorSelected = { viewModel.updateIconColor(it) },
                         //enabled = !isLoading
                     )


### PR DESCRIPTION
This commit refactors the "Create Space" screen and improves the Color Picker component.

Key Changes:

- **CreateSpaceScreen.kt:**
    - Changed `IconPicker` category from `GroupIconCategory.HOUSE` to `GroupIconCategory.SPACE`.
    - Removed unused state variables `spaceName` and `selectedRole`.
    - Ensures `iconName` is updated in the ViewModel even if `sel` (selected icon) is null, defaulting to "home".
- **ColorPicker.kt:**
    - Updated the list of colors to use color names (e.g., "blue", "red") instead of hex codes for the `onColorSelected` callback. The display still uses `Color` objects.
- **parseColorOrDefault.kt:**
    - Modified the `String.toColor()` extension function to also accept hex color codes as input strings, in addition to color names.
- **SpaceRepositoryImpl.kt:**
    - Improved token handling by using `authManager.getJwtToken().orEmpty()` to prevent potential null pointer exceptions.
    - Refactored `deleteSpace` and `updateSpace` methods to use `runCatching` for cleaner error handling.
- **Screens.kt:**
    - Commented out the `AddSpace` screen object as it appears to be unused or deprecated.
- **HouseDetailScreen.kt:**
    - Added logging for space details when updating a space.