### PR TITLE
refactor: Update HomeScreen layout and remove CameraDetailScreen

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/navigation/Drawer.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/navigation/Drawer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -102,7 +103,9 @@ fun DrawerWithContent(
             )
         },
         content = {
-            Column {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
                 Header(
                     navController = navController,
                     type = type,

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
@@ -9,9 +9,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import androidx.navigation.navigation
-import com.sns.homeconnect_v2.presentation.navigation.Screens.EditSpaceWithHouse
-import com.google.gson.Gson
-import com.sns.homeconnect_v2.data.remote.dto.response.ProductData
 import com.sns.homeconnect_v2.presentation.screen.auth.ForgotPasswordScreen
 import com.sns.homeconnect_v2.presentation.screen.auth.LoginScreen
 import com.sns.homeconnect_v2.presentation.screen.auth.RecoverPasswordScreen
@@ -40,14 +37,12 @@ import com.sns.homeconnect_v2.presentation.screen.group.user.AddUserScreen
 import com.sns.homeconnect_v2.presentation.screen.house.HouseSearchScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.DefaultDetailScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.ListDeviceScreen
-import com.sns.homeconnect_v2.presentation.screen.iot_device.FireAlarmDetailScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.SoftwareVersionScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.ReportLostDeviceScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.TransferOwnershipScreen
 import com.sns.homeconnect_v2.presentation.viewmodel.snackbar.SnackbarViewModel
 import com.sns.homeconnect_v2.presentation.viewmodel.space.SpaceScreenViewModel
 import com.sns.homeconnect_v2.presentation.screen.group.house.space.DetailSpaceScreen
-import com.sns.homeconnect_v2.presentation.screen.iot_device.CameraDetailScreen
 import com.sns.homeconnect_v2.presentation.screen.iot_device.DynamicDeviceDetailScreen
 import com.sns.homeconnect_v2.presentation.screen.ticket.CreateTicketScreen
 import com.sns.homeconnect_v2.presentation.screen.ticket.TicketDetailScreen
@@ -430,25 +425,6 @@ fun NavigationGraph(navController: NavHostController, snackbarViewModel: Snackba
             ) {
                 CreateTicketScreen(
                     navController     = navController,
-                    snackbarViewModel = snackbarViewModel
-                )
-            }
-
-            /* ---------- Camera screens ---------- */
-            composable(
-                route = Screens.CameraDetail.route,
-                arguments = listOf(
-                    navArgument("deviceId")   { type = NavType.StringType },
-                    navArgument("deviceName") { type = NavType.StringType }
-                )
-            ) { backStackEntry ->
-                val deviceId   = backStackEntry.arguments?.getString("deviceId") ?: ""
-                val deviceName = backStackEntry.arguments?.getString("deviceName") ?: ""
-
-                CameraDetailScreen(
-                    navController     = navController,
-                    deviceId          = deviceId,
-                    deviceName        = deviceName,
                     snackbarViewModel = snackbarViewModel
                 )
             }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/home/HomeScreen.kt
@@ -2,8 +2,10 @@ package com.sns.homeconnect_v2.presentation.screen.home
 
 import IoTHomeConnectAppTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.waterfall
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -146,6 +148,7 @@ fun HomeScreen(
             username="Sang",
             content = {
                 Scaffold(
+                    contentWindowInsets = WindowInsets.waterfall,
                     containerColor = colorScheme.background,
                     modifier = Modifier.fillMaxSize(),
                     bottomBar = {


### PR DESCRIPTION
This commit introduces layout adjustments to `HomeScreen` and removes the `CameraDetailScreen` and its associated navigation graph entry.

Key changes:

- **HomeScreen.kt:**
    - Applied `WindowInsets.waterfall` to the `Scaffold` to improve layout with system UI elements.
- **Drawer.kt:**
    - Modified the `Column` within the `DrawerContent` to use `Modifier.fillMaxSize()` for better responsiveness.
- **NavigationGraph.kt:**
    - Removed the composable entry for `Screens.CameraDetail`.