### PR TITLE
Refactor(component): Enhance swipeable cards with disabled state and …

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/di/NetworkModule.kt
@@ -20,7 +20,7 @@ object NetworkModule {
     @Named("HomeConnectRetrofit")
     fun provideHomeConnectRetrofit(): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("http://10.0.2.2:7777/api/") // Thay đổi thành localhost/IP thật
+            .baseUrl("https://iothomeconnectapiv2-production.up.railway.app/api/") // Thay đổi thành localhost/IP thật
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/GroupCardSwipeable.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/GroupCardSwipeable.kt
@@ -75,16 +75,16 @@ fun GroupCardSwipeable(
 
             ActionIcon(
                 onClick = onEdit,
-                backgroundColor = Color(0xFF4CAF50),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Edit) // ✅ sửa chỗ này
+                backgroundColor = if (canEdit) Color(0xFF4CAF50) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Edit),
+                enabled = canEdit
             )
-
             Spacer(Modifier.width(8.dp))
-
             ActionIcon(
                 onClick = onDelete,
-                backgroundColor = Color(0xFFF44336),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Delete) // ✅ sửa chỗ này
+                backgroundColor = if (canDelete) Color(0xFFF44336) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Delete),
+                enabled = canDelete,
             )
 
         }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/HouseCardSwipeable.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/HouseCardSwipeable.kt
@@ -70,16 +70,18 @@ fun HouseCardSwipeable(
 
             ActionIcon(
                 onClick = onEdit,
-                backgroundColor = Color(0xFF4CAF50),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Edit) // ✅ sửa chỗ này
+                backgroundColor = if (canEdit) Color(0xFF4CAF50) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Edit), // ✅ sửa chỗ này
+                enabled = canEdit
             )
 
             Spacer(Modifier.width(8.dp))
 
             ActionIcon(
                 onClick = onDelete,
-                backgroundColor = Color(0xFFF44336),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Delete) // ✅ sửa chỗ này
+                backgroundColor = if (canDelete) Color(0xFFF44336) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Delete), // ✅ sửa chỗ này
+                enabled = canDelete
             )
 
         }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/SpaceCardSwipeable.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/SpaceCardSwipeable.kt
@@ -51,16 +51,18 @@ fun SpaceCardSwipeable(
 
             ActionIcon(
                 onClick = onEdit,
-                backgroundColor = Color(0xFF4CAF50),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Edit) // ✅ sửa chỗ này
+                backgroundColor = if (canEdit) Color(0xFF4CAF50) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Edit), // ✅ sửa chỗ này
+                enabled = canEdit
             )
 
             Spacer(Modifier.width(8.dp))
 
             ActionIcon(
                 onClick = onDelete,
-                backgroundColor = Color(0xFFF44336),
-                icon = ActionIconContent.VectorIcon(Icons.Default.Delete) // ✅ sửa chỗ này
+                backgroundColor = if (canDelete) Color(0xFFF44336) else Color.LightGray,
+                icon = ActionIconContent.VectorIcon(Icons.Default.Delete), // ✅ sửa chỗ này
+                enabled = canDelete
             )
 
         }


### PR DESCRIPTION
…update API endpoint

This commit introduces several improvements:
- Updated the API endpoint in `NetworkModule.kt` from `http://10.0.2.2:7777/api/` to `https://iothomeconnectapiv2-production.up.railway.app/api/`.
- Modified `SpaceCardSwipeable.kt`, `HouseCardSwipeable.kt`, and `GroupCardSwipeable.kt` to disable edit and delete actions based on `canEdit` and `canDelete` flags.
- When an action is disabled, its background color changes to `Color.LightGray`, and the `enabled` property of `ActionIcon` is set to `false`.