### PR TITLE
feat(ui): Implement Door Control Widget and Detail Screen

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/core/di/NetworkModule.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/core/di/NetworkModule.kt
@@ -20,7 +20,7 @@ object NetworkModule {
     @Named("HomeConnectRetrofit")
     fun provideHomeConnectRetrofit(): Retrofit {
         return Retrofit.Builder()
-            .baseUrl("http://10.0.2.2:7777/api/") // Thay đổi thành localhost/IP thật
+            .baseUrl("https://iothomeconnectapiv2-production.up.railway.app/api/") // Thay đổi thành localhost/IP thật
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/door/DoorActionButton.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/door/DoorActionButton.kt
@@ -1,0 +1,89 @@
+package com.sns.homeconnect_v2.presentation.component.widget.door
+
+import androidx.compose.ui.res.painterResource
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DoorBack
+import androidx.compose.material.icons.filled.DoorFront
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sns.homeconnect_v2.R
+
+@Composable
+fun DoorActionButton(
+    isOpen: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val label = if (isOpen) "Đóng cửa" else "Mở cửa"
+    val iconRes = if (isOpen) R.drawable.door_closed else R.drawable.door_open
+    val backgroundColor = if (isOpen) Color(0xFFFFEBEE) else Color(0xFFE3F2FD)
+    val contentColor = if (isOpen) Color(0xFFD32F2F) else Color(0xFF1565C0)
+
+    Surface(
+        onClick = onClick,
+        modifier = modifier
+            .width(160.dp)
+            .height(140.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = backgroundColor,
+        shadowElevation = 6.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Surface(
+                shape = CircleShape,
+                color = Color.White,
+                modifier = Modifier.size(56.dp),
+                tonalElevation = 2.dp
+            ) {
+                Image(
+                    painter = painterResource(id = iconRes),
+                    contentDescription = label,
+                    modifier = Modifier
+                        .padding(12.dp)
+                        .fillMaxSize(),
+                    colorFilter = ColorFilter.tint(contentColor)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = label,
+                color = contentColor,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewInteractiveDoorActionButton() {
+    var isOpen by remember { mutableStateOf(false) }
+
+    DoorActionButton(
+        isOpen = isOpen,
+        onClick = { isOpen = !isOpen }
+    )
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/door/DoorControlWidget.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/door/DoorControlWidget.kt
@@ -1,0 +1,212 @@
+package com.sns.homeconnect_v2.presentation.component.widget.door
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Loại cửa: truyền thống, trượt ngang, cuốn lên.
+ */
+enum class DoorType(val label: String) {
+    TRADITIONAL("Cửa truyền thống"),
+    SLIDING("Cửa trượt"),
+    ROLLER("Cửa cuốn")
+}
+
+// Thời gian animation chậm hơn (ms)
+private const val ANIM_DURATION = 900
+
+/* ---------------------- DOOR CANVAS ---------------------- */
+@Composable
+fun DoorCanvas(
+    doorType: DoorType,
+    isOpen: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val borderColor = if (isOpen) Color(0xFF4CAF50) else Color(0xFF1565C0)
+    val lockIcon = if (isOpen) Icons.Default.LockOpen else Icons.Default.Lock
+    val doorBg = Color(0xFFB0C6E0)
+
+    Surface(
+        shape = RoundedCornerShape(24.dp),
+        shadowElevation = 8.dp,
+        modifier = modifier
+            .aspectRatio(1f)
+            .clickable { onToggle() }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(20.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            /*** DRAW SPECIFIC DOOR ***/
+            when (doorType) {
+                DoorType.TRADITIONAL   -> TraditionalDoor(isOpen, doorBg, borderColor)
+                DoorType.SLIDING       -> SlidingDoor(isOpen, doorBg, borderColor)
+                DoorType.ROLLER        -> RollerDoor(isOpen, doorBg, borderColor)
+            }
+
+            /*** LOCK OVERLAY ***/
+            Surface(
+                modifier = Modifier.size(64.dp),
+                shape = CircleShape,
+                color = Color.White,
+                shadowElevation = 4.dp
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(lockIcon, contentDescription = null, tint = borderColor)
+                }
+            }
+        }
+    }
+}
+
+/* ---------------------- DOOR IMPLEMENTATIONS ---------------------- */
+@Composable
+private fun TraditionalDoor(isOpen: Boolean, bg: Color, borderColor: Color) {
+    // animate width fraction (1f closed -> 0.25f open)
+    val fraction by animateFloatAsState(
+        targetValue = if (isOpen) 0.25f else 1f,
+        animationSpec = tween(ANIM_DURATION, easing = FastOutSlowInEasing)
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(16.dp))
+            .border(2.dp, borderColor, RoundedCornerShape(16.dp))
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(fraction)
+                .background(bg)
+        )
+        // knob
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 8.dp)
+                .size(width = 6.dp, height = 40.dp)
+                .background(Color.Gray, RoundedCornerShape(3.dp))
+        )
+    }
+}
+
+@Composable
+private fun SlidingDoor(isOpen: Boolean, bg: Color, borderColor: Color) {
+    val offset by animateFloatAsState(
+        targetValue = if (isOpen) 0.6f else 0f,
+        animationSpec = tween(ANIM_DURATION, easing = FastOutSlowInEasing)
+    )
+    val panelWidth = 0.5f
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(16.dp))
+            .border(2.dp, borderColor, RoundedCornerShape(16.dp))
+    ) {
+        // left panel
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(panelWidth)
+                .offset(x = (-offset * 100).dp) // smoother conversion
+                .background(bg)
+        )
+        // right panel
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .fillMaxWidth(panelWidth)
+                .offset(x = (offset * 100).dp)
+                .background(bg)
+        )
+        // central handle
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .size(width = 4.dp, height = 60.dp)
+                .background(borderColor)
+        )
+    }
+}
+
+@Composable
+private fun RollerDoor(isOpen: Boolean, bg: Color, borderColor: Color) {
+    val fraction by animateFloatAsState(
+        targetValue = if (isOpen) 0f else 1f,
+        animationSpec = tween(ANIM_DURATION, easing = FastOutSlowInEasing)
+    )
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(16.dp))
+            .border(2.dp, borderColor, RoundedCornerShape(16.dp))
+    ) {
+        // top hood
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp)
+                .background(Color.LightGray)
+        )
+
+        // door sheet
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(fraction)
+                .align(Alignment.TopCenter)
+        ) {
+            Column(Modifier.fillMaxSize()) {
+                repeat(10) {
+                    Box(
+                        Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .background(bg)
+                            .border(0.5.dp, Color.White)
+                    )
+                }
+            }
+        }
+    }
+}
+
+/* ---------------------- PREVIEW ---------------------- */
+@Preview(showBackground = true)
+@Composable
+fun DoorControlWidgetPreview() {
+    var type by remember { mutableStateOf(DoorType.TRADITIONAL) }
+    var open by remember { mutableStateOf(false) }
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        DoorCanvas(doorType = type, isOpen = open, onToggle = { open = !open })
+    }
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/iot_device/DoorDetailScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/iot_device/DoorDetailScreen.kt
@@ -1,0 +1,219 @@
+package com.sns.homeconnect_v2.presentation.screen.iot_device
+
+import IoTHomeConnectAppTheme
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Wifi
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sns.homeconnect_v2.presentation.component.CustomSwitch
+import com.sns.homeconnect_v2.presentation.component.widget.ColoredCornerBox
+import com.sns.homeconnect_v2.presentation.component.widget.InvertedCornerHeader
+import com.sns.homeconnect_v2.presentation.component.widget.door.DoorActionButton
+import com.sns.homeconnect_v2.presentation.component.widget.door.DoorCanvas
+import com.sns.homeconnect_v2.presentation.component.widget.door.DoorType
+import com.sns.homeconnect_v2.presentation.navigation.Screens
+import com.sns.homeconnect_v2.presentation.viewmodel.snackbar.SnackbarViewModel
+
+@Composable
+fun DoorDetailScreen(
+    deviceId: String,
+    deviceName: String,
+    serialNumber: String,
+    controls: Map<String, String>,
+    isViewOnly: Boolean = true,
+    snackbarViewModel: SnackbarViewModel = hiltViewModel(),
+) {
+    /* ---------- STATE ---------- */
+    var doorType by remember { mutableStateOf(DoorType.SLIDING) }
+    var isOpen   by remember { mutableStateOf(false) }
+
+    var powerStatusUI by remember { mutableStateOf(false) }
+    var isPowerUpdating by remember { mutableStateOf(false) }
+
+    var pendingPowerStatus by remember { mutableStateOf<Boolean?>(null) }
+
+    val colorScheme = MaterialTheme.colorScheme
+
+    IoTHomeConnectAppTheme {
+        Scaffold(
+            topBar = {
+            },
+            bottomBar = {
+            },
+            containerColor = colorScheme.background,
+            modifier = Modifier.fillMaxSize(),
+            content = { innerPadding ->
+                LazyColumn(
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    contentPadding = PaddingValues(bottom = 32.dp)
+                ) {
+                    /** ---- VÙNG CANVAS ---- */
+                    item {
+                        ColoredCornerBox(
+                            cornerRadius = 40.dp
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                            ) {
+                                // BÊN TRÁI: Thông tin thiết bị
+                                Column(
+                                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                                    horizontalAlignment = Alignment.Start
+                                ) {
+                                    Text(
+                                        text = deviceName,
+                                        color = colorScheme.onPrimary,
+                                        fontSize = 20.sp,
+                                        lineHeight = 28.sp,
+                                        style = MaterialTheme.typography.titleMedium,
+                                        fontWeight = FontWeight.SemiBold,
+                                        letterSpacing = 0.5.sp
+                                    )
+
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        Text(
+                                            text = "Bật/Tắt",
+                                            color = colorScheme.onPrimary,
+                                            fontSize = 14.sp
+                                        )
+                                        CustomSwitch(
+                                            isCheck = powerStatusUI,
+                                            enabled = !isPowerUpdating,
+                                            onCheckedChange = { newStatus ->
+                                                pendingPowerStatus = newStatus
+                                                isPowerUpdating = true
+                                            }
+                                        )
+                                    }
+
+                                    Column(
+                                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                                    ) {
+                                        Text(
+                                            text = "Trạng thái cửa:",
+                                            color = colorScheme.onPrimary,
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Normal
+                                        )
+
+                                        Text(
+                                            text = if (isOpen) "Đang mở" else "Đang đóng",
+                                            color = if (isOpen) Color(0xFFFF0000) else Color(0xFF00FF19),
+                                            fontSize = 16.sp,
+                                            fontWeight = FontWeight.SemiBold,
+                                            letterSpacing = 0.3.sp
+                                        )
+                                    }
+                                }
+
+                                Spacer(Modifier.width(16.dp))
+
+                                // BÊN PHẢI: Cửa đẹp hơn
+                                Box(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .aspectRatio(1f),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    DoorCanvas(
+                                        doorType = doorType,
+                                        isOpen = isOpen,
+                                        onToggle = { if (!isViewOnly) isOpen = !isOpen },
+                                        modifier = Modifier
+                                            .fillMaxSize(1f)
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    /** ---- DẢI HEADER VỚI SELECTOR ---- */
+                    item {
+                        InvertedCornerHeader(
+                            backgroundColor = colorScheme.surface,
+                            overlayColor = colorScheme.primary
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                /* ---------- INFO ---------- */
+                                IconButton(
+                                    onClick = {
+                                    },
+                                    modifier = Modifier.size(32.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Info,
+                                        contentDescription = "Info",
+                                        tint = colorScheme.primary,
+                                        modifier = Modifier.size(32.dp)
+                                    )
+                                }
+
+                                /* ---------- WIFI ---------- */
+                                IconButton(
+                                    onClick = {
+                                    },
+                                    modifier = Modifier.size(32.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Wifi,
+                                        contentDescription = "Wi-Fi",
+                                        tint = colorScheme.primary,
+                                        modifier = Modifier.size(32.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    /** ---- BUTTON MỞ/ĐÓNG ---- */
+                    item {
+                        Spacer(Modifier.height(12.dp))
+                        DoorActionButton(
+                            isOpen = isOpen,
+                            onClick = { isOpen = !isOpen }
+                        )
+                    }
+                }
+            }
+        )
+    }
+}
+
+/* ---------------- PREVIEW ---------------- */
+@Preview(showBackground = true)
+@Composable
+private fun DoorDetailScreenPreview() {
+    DoorDetailScreen(
+        deviceId = "DEVICE001",
+        deviceName = "Cửa chính",
+        serialNumber = "SERIAL123456",
+        controls = mapOf("power_status" to "toggle"),
+        isViewOnly = true,
+        snackbarViewModel = remember { SnackbarViewModel() }
+    )
+}

--- a/app/src/main/res/drawable/door_closed.xml
+++ b/app/src/main/res/drawable/door_closed.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M23,22h-3L20,5c0,-2.757 -2.243,-5 -5,-5h-6c-2.757,0 -5,2.243 -5,5L4,22L1,22c-0.553,0 -1,0.448 -1,1s0.447,1 1,1L23,24c0.553,0 1,-0.448 1,-1s-0.447,-1 -1,-1ZM15.5,14c-0.828,0 -1.5,-0.672 -1.5,-1.5s0.672,-1.5 1.5,-1.5 1.5,0.672 1.5,1.5 -0.672,1.5 -1.5,1.5Z"/>
+</vector>

--- a/app/src/main/res/drawable/door_open.xml
+++ b/app/src/main/res/drawable/door_open.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M23,22h-3L20,6c0,-2.206 -1.794,-4 -4,-4h-0.535c-0.238,-0.411 -0.55,-0.782 -0.929,-1.092C13.606,0.146 12.396,-0.157 11.216,0.079l-3.197,0.639c-2.329,0.466 -4.019,2.528 -4.019,4.903L4,22L1,22c-0.552,0 -1,0.447 -1,1s0.448,1 1,1L23,24c0.552,0 1,-0.447 1,-1s-0.448,-1 -1,-1ZM11.5,14c-0.828,0 -1.5,-0.672 -1.5,-1.5s0.672,-1.5 1.5,-1.5 1.5,0.672 1.5,1.5 -0.672,1.5 -1.5,1.5ZM18,22h-2L16,4c1.103,0 2,0.897 2,2L18,22Z"/>
+</vector>


### PR DESCRIPTION
This commit introduces a new UI component for controlling doors and a corresponding detail screen.

**New Components:**
- `DoorControlWidget.kt`:
    - Defines `DoorType` enum (TRADITIONAL, SLIDING, ROLLER).
    - `DoorCanvas`: A composable that visually represents a door based on its type and open/closed state. It includes animations for state changes and a lock icon overlay.
    - Specific door implementations: `TraditionalDoor`, `SlidingDoor`, `RollerDoor`, each with unique animations for opening and closing.
- `DoorActionButton.kt`:
    - A composable button to toggle the door state (Open/Close).
    - Displays different icons (`door_open.xml`, `door_closed.xml`) and background/content colors based on the door's state.

**New Screen:**
- `DoorDetailScreen.kt`:
    - Displays detailed information and controls for a door device.
    - Integrates `DoorCanvas` to show the door's visual state.
    - Uses `DoorActionButton` for user interaction to open/close the door.
    - Includes a power status switch and displays the current door state (Đang mở/Đang đóng).
    - Features a `ColoredCornerBox` for the top device information section and an `InvertedCornerHeader` for secondary actions (Info, Wi-Fi).

**New Drawables:**
- `door_open.xml`: Vector drawable for an open door.
- `door_closed.xml`: Vector drawable for a closed door.

**API Endpoint Update:**
- `NetworkModule.kt`: The base URL for `HomeConnectRetrofit` has been updated to `https://iothomeconnectapiv2-production.up.railway.app/api/`.

#155