### PR TITLE
Refactor(ui): Improve navigation and update GroupScreen FAB

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/FeatureButtonRow.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/FeatureButtonRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sns.homeconnect_v2.presentation.model.FeatureButtonItem
+import com.sns.homeconnect_v2.presentation.navigation.Screens
 
 @Composable
 fun FeatureButtonRow(
@@ -34,10 +35,14 @@ fun FeatureButtonRow(
 @Composable
 fun FeatureButtonRowPreview() {
     val items = listOf(
-        FeatureButtonItem(Icons.Default.Add, "Thêm thiết bị") {},
+        FeatureButtonItem(Icons.Default.Add, "Thêm thiết bị") {
+        },
         FeatureButtonItem(Icons.Default.Wifi, "Kết nối Wifi") {},
-        FeatureButtonItem(Icons.Default.Upload, "Chia sẻ thiết bị") {},
-        FeatureButtonItem(Icons.Default.PhoneAndroid, "Thiết bị của tôi") {}
+        FeatureButtonItem(Icons.Default.Upload, "Chia sẻ thiết bị") {
+        },
+        FeatureButtonItem(Icons.Default.PhoneAndroid, "Thiết bị của tôi") {
+
+        }
     )
     FeatureButtonRow(items = items, modifier = Modifier.padding(vertical = 8.dp))
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/CreateGroupScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/CreateGroupScreen.kt
@@ -41,9 +41,7 @@ fun CreateGroupScreen(
         is CreateGroupState.Success -> {
             LaunchedEffect(Unit) {
                 snackbarViewModel.showSnackbar("Thêm nhóm thành cộng!", SnackbarVariant.SUCCESS)
-                navController.navigate("home") {
-                    popUpTo("create_group") { inclusive = true }
-                }
+                navController.popBackStack()
             }
         }
 

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/GroupScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/group/GroupScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.sns.homeconnect_v2.core.util.validation.SnackbarVariant
@@ -102,31 +104,6 @@ fun GroupScreen(
 
     IoTHomeConnectAppTheme {
         val colorScheme = MaterialTheme.colorScheme
-        val fabChildren = listOf(
-            FabChild(
-                icon = Icons.Default.Edit,
-                onClick = { /* TODO: chỉnh sửa nhóm */ },
-                containerColor = colorScheme.primary,
-                contentColor = colorScheme.onPrimary
-            ),
-            FabChild(
-                icon = Icons.Default.Delete,
-                onClick = {
-                    snackbarViewModel.showSnackbar(
-                        msg = "Vui lòng chọn một nhóm để xóa",
-                        variant = SnackbarVariant.WARNING
-                    )
-                },
-                containerColor = colorScheme.primary,
-                contentColor = colorScheme.onPrimary
-            ),
-            FabChild(
-                icon = Icons.Default.Share,
-                onClick = { /* TODO: chia sẻ nhóm */ },
-                containerColor = colorScheme.primary,
-                contentColor = colorScheme.onPrimary
-            )
-        )
 
         Scaffold(
             topBar = {
@@ -138,13 +115,27 @@ fun GroupScreen(
             },
             containerColor = Color.White,
             floatingActionButton = {
-                RadialFab(
-                    items = fabChildren,
-                    radius = 120.dp,
-                    startDeg = -90f,
-                    sweepDeg = -90f,
-                    onParentClick = { /* TODO: thêm nhóm mới */ }
-                )
+                FloatingActionButton(
+                    onClick = {
+                        snackbarViewModel.showSnackbar("Đã nhấn nút thêm!")
+                        navController.navigate(Screens.CreateGroup.route)
+                    },
+                    containerColor = colorScheme.primary ?: Color(0xFF6200EE),
+                    contentColor = colorScheme.onPrimary ?: Color.White,
+                    modifier = Modifier.size(60.dp)
+                ) {
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        Text(
+                            text = "+",
+                            fontSize = 24.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = colorScheme.onPrimary ?: Color.White
+                        )
+                    }
+                }
             },
             floatingActionButtonPosition = FabPosition.End,
             bottomBar = {

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/home/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.filled.BorderAll
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Groups
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Memory
@@ -71,12 +72,18 @@ fun HomeScreen(
         SlideShowItem("https://picsum.photos/id/3/600/300")
     )
     val featureButtons = listOf(
-        FeatureButtonItem(Icons.Default.Add, "Thêm thiết bị") {},
-        FeatureButtonItem(Icons.Default.Wifi, "Kết nối Wifi") {},
+        FeatureButtonItem(Icons.Default.Add, "Thêm thiết bị") {
+            navController.navigate(Screens.AddDevice.route)
+        },
+        FeatureButtonItem(Icons.Default.Groups, "Nhóm thiết bị") {
+            navController.navigate(Screens.Groups.route)
+        },
         FeatureButtonItem(Icons.Default.Upload, "Dashboard") {
             navController.navigate(Screens.Dashboard.route)
         },
-        FeatureButtonItem(Icons.Default.PhoneAndroid, "Thiết bị của tôi") {}
+        FeatureButtonItem(Icons.Default.PhoneAndroid, "Thiết bị của tôi") {
+            navController.navigate(Screens.ListDevices.route)
+        }
     )
     val deviceStats = listOf(
         DeviceStatCardItem(Icons.Default.Memory , Color(0xFFF54B63), "Tổng số thiết bị", "12 thiết bị"),


### PR DESCRIPTION
This commit introduces several UI and navigation improvements:

- **CreateGroupScreen:** Changed navigation from `navController.navigate("home")` with `popUpTo("create_group")` to a simpler `navController.popBackStack()` upon successful group creation. This provides a more standard back navigation behavior.
- **HomeScreen:**
    - Updated `FeatureButtonItem` for "Thêm thiết bị" to navigate to `Screens.AddDevice.route`.
    - Added a new `FeatureButtonItem` for "Nhóm thiết bị" which navigates to `Screens.Groups.route`.
    - Updated `FeatureButtonItem` for "Thiết bị của tôi" to navigate to `Screens.ListDevices.route`.
- **GroupScreen:**
    - Replaced the `RadialFab` with a standard `FloatingActionButton`.
    - The new FAB displays a "+" sign and, when clicked, navigates to `Screens.CreateGroup.route` and shows a snackbar message "Đã nhấn nút thêm!".