### PR TITLE
Feat: Implement approve share permission functionality

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -553,6 +553,13 @@ interface ApiService {
         @Header("Authorization") token: String
     ): Response<Unit>
 
+    @POST("shared-permissions/{ticketId}/approve")
+    suspend fun approveSharePermission(
+        @Path("ticketId") ticketId: String,
+        @Body body: Map<String, Boolean>,
+        @Header("Authorization") token: String
+    ): Response<Unit>
+
 //    @POST("spaces")
 //    suspend fun createSpace(
 //        @Body body: CreateSpaceRequest,

--- a/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
@@ -34,4 +34,14 @@ class SharedRepositoryImpl @Inject constructor(
         val token = authManager.getJwtToken()
         return apiService.revokePermission(permissionId = permissionID, token = "Bearer $token")
     }
+
+    override suspend fun approveSharePermission(ticketId: String): Response<Unit> {
+        val token = authManager.getJwtToken()
+        val body = mapOf("accept" to true)
+        return apiService.approveSharePermission(
+            ticketId = ticketId,
+            body = body,
+            token = "Bearer $token"
+        )
+    }
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/repository/SharedRepository.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/repository/SharedRepository.kt
@@ -12,4 +12,6 @@ interface SharedRepository {
     suspend fun addSharedUser(deviceId: Int, sharedWithUserEmail: String): Response<Unit>
 
     suspend fun revokePermission(permissionID: Int):   Response<Unit>
+
+    suspend fun approveSharePermission(ticketId: String): Response<Unit>
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/iot_device/ApproveSharePermissionUseCase.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/iot_device/ApproveSharePermissionUseCase.kt
@@ -1,0 +1,17 @@
+package com.sns.homeconnect_v2.domain.usecase.iot_device
+
+import com.sns.homeconnect_v2.domain.repository.SharedRepository
+import javax.inject.Inject
+
+class ApproveSharePermissionUseCase @Inject constructor(
+    private val sharedRepository: SharedRepository
+) {
+    suspend operator fun invoke(ticketId: String): Result<Unit> {
+        return try {
+            sharedRepository.approveSharePermission(ticketId)
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/ApprovePermissionDialog.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/ApprovePermissionDialog.kt
@@ -1,0 +1,57 @@
+package com.sns.homeconnect_v2.presentation.component
+
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sns.homeconnect_v2.presentation.viewmodel.iot_device.ApprovePermissionViewModel
+import com.sns.homeconnect_v2.presentation.viewmodel.iot_device.PermissionUiState
+
+@Composable
+fun ApprovePermissionDialog(
+    ticketId: String,
+    onDismiss: () -> Unit,
+    onApproved: () -> Unit,
+    viewModel: ApprovePermissionViewModel = hiltViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(state) {
+        if (state is PermissionUiState.Success) {
+            onApproved()
+            onDismiss()
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(text = "Xác nhận chia sẻ quyền")
+        },
+        text = {
+            when (state) {
+                is PermissionUiState.Loading -> {
+                    CircularProgressIndicator()
+                }
+                is PermissionUiState.Error -> {
+                    Text(text = "Lỗi: ${(state as PermissionUiState.Error).message}")
+                }
+                else -> {
+                    Text("Bạn có muốn chấp nhận yêu cầu chia sẻ thiết bị không?")
+                }
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = { viewModel.approve(ticketId) },
+                enabled = state !is PermissionUiState.Loading
+            ) {
+                Text("Chấp nhận")
+            }
+        },
+        dismissButton = {
+            OutlinedButton(onClick = onDismiss) {
+                Text("Huỷ")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ActionButtonWithFeedback.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/component/widget/ActionButtonWithFeedback.kt
@@ -1,4 +1,4 @@
-package com.sns.homeconnect_v2.presentation.component.widget
+    package com.sns.homeconnect_v2.presentation.component.widget
 
 import IoTHomeConnectAppTheme
 import androidx.compose.foundation.BorderStroke

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/DeviceScreenFactory.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/DeviceScreenFactory.kt
@@ -27,7 +27,7 @@ object DeviceScreenFactory {
         Log.d("CHECK", "parentName='$parentName', normalized='$normalized', isViewOnly=$isViewOnly, controls=$controls")
 
         return when {
-            normalized == "Đèn Led" -> { navController ->
+            normalized == "đèn led" -> { navController ->
                 DeviceDetailScreen(
                     navController = navController,
                     deviceId = deviceId,

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/iot_device/ApprovePermissionViewModel.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/iot_device/ApprovePermissionViewModel.kt
@@ -1,0 +1,40 @@
+package com.sns.homeconnect_v2.presentation.viewmodel.iot_device
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sns.homeconnect_v2.domain.usecase.iot_device.ApproveSharePermissionUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import jakarta.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ApprovePermissionViewModel @Inject constructor(
+    private val approveSharePermissionUseCase: ApproveSharePermissionUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow<PermissionUiState>(PermissionUiState.Idle)
+    val state = _state.asStateFlow()
+
+    fun approve(ticketId: String) {
+        _state.value = PermissionUiState.Loading
+        viewModelScope.launch {
+            approveSharePermissionUseCase(ticketId).fold(
+                onSuccess = {
+                    _state.value = PermissionUiState.Success
+                },
+                onFailure = {
+                    _state.value = PermissionUiState.Error(it.message ?: "Có lỗi xảy ra")
+                }
+            )
+        }
+    }
+}
+
+sealed class PermissionUiState {
+    object Idle : PermissionUiState()
+    object Loading : PermissionUiState()
+    object Success : PermissionUiState()
+    data class Error(val message: String) : PermissionUiState()
+}


### PR DESCRIPTION
This commit introduces the ability for users to approve share permission requests.

Key changes:
- Added `approveSharePermission` endpoint to `ApiService`.
- Implemented `approveSharePermission` in `SharedRepositoryImpl` and `SharedRepository`.
- Created `ApproveSharePermissionUseCase` to handle the approval logic.
- Developed `ApprovePermissionViewModel` and `PermissionUiState` to manage UI state.
- Introduced `ApprovePermissionDialog` composable to display the confirmation dialog.
- Integrated the approval dialog into `TicketListScreen`: when a "Chia sẻ quyền" ticket is clicked, the dialog is shown. Upon successful approval, the ticket list is refreshed and a success snackbar is displayed.
- Corrected device name normalization in `DeviceScreenFactory` to lowercase "đèn led".
- Minor code formatting adjustment in `ActionButtonWithFeedback.kt`.