### PR TITLE
Refactor: Update approve share permission request body

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/request/ApproveRequest.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/dto/request/ApproveRequest.kt
@@ -1,0 +1,6 @@
+package com.sns.homeconnect_v2.data.remote.dto.request
+
+data class ApproveRequest(
+    var ticketId: String,
+    var isApproved: Boolean = true
+)

--- a/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.sns.homeconnect_v2.data.repository
 
 import com.sns.homeconnect_v2.data.AuthManager
 import com.sns.homeconnect_v2.data.remote.api.ApiService
+import com.sns.homeconnect_v2.data.remote.dto.request.ApproveRequest
 import com.sns.homeconnect_v2.data.remote.dto.response.SharedDeviceResponse
 import com.sns.homeconnect_v2.data.remote.dto.response.SharedUser
 import com.sns.homeconnect_v2.data.remote.dto.response.SharedUserRequest
@@ -37,10 +38,9 @@ class SharedRepositoryImpl @Inject constructor(
 
     override suspend fun approveSharePermission(ticketId: String): Response<Unit> {
         val token = authManager.getJwtToken()
-        val body = mapOf("accept" to true)
+        val approveRequest = ApproveRequest(ticketId = ticketId, isApproved = true)
         return apiService.approveSharePermission(
-            ticketId = ticketId,
-            body = body,
+            request = approveRequest,
             token = "Bearer $token"
         )
     }


### PR DESCRIPTION
This commit refactors the `approveSharePermission` method in `SharedRepositoryImpl.kt` to send a structured `ApproveRequest` object as the request body instead of a simple map.

A new data class `ApproveRequest.kt` has been created to represent this request, containing `ticketId` and `isApproved` fields.