### PR TITLE
feat(sharing): Implement revoke recipient permission

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -575,6 +575,13 @@ interface ApiService {
         @Body body: ToggleDoorRequest,
         @Header("Authorization") token: String
     ): DoorToggleResponse
+
+    @DELETE("permissions/recipient/{serialNumber}")
+    suspend fun revokeRecipientPermission(
+        @Path("serialNumber") serial: String,
+        @Header("Authorization") bearer: String   // "Bearer <JWT>"
+    ): Response<Unit>
+
 //    @POST("spaces")
 //    suspend fun createSpace(
 //        @Body body: CreateSpaceRequest,

--- a/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/repository/SharedRepositoryImpl.kt
@@ -44,4 +44,9 @@ class SharedRepositoryImpl @Inject constructor(
             token = "Bearer $token"
         )
     }
+
+    override suspend fun revokeRecipientPermission(serialNumber: String): Response<Unit> {
+        val token = "Bearer ${authManager.getJwtToken()}"
+        return apiService.revokeRecipientPermission(serialNumber, token)
+    }
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/repository/SharedRepository.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/repository/SharedRepository.kt
@@ -14,4 +14,6 @@ interface SharedRepository {
     suspend fun revokePermission(permissionID: Int):   Response<Unit>
 
     suspend fun approveSharePermission(ticketId: String): Response<Unit>
+
+    suspend fun revokeRecipientPermission(serialNumber: String): Response<Unit>
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/iot_device/sharing/RevokeRecipientPermissionUseCase.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/iot_device/sharing/RevokeRecipientPermissionUseCase.kt
@@ -1,0 +1,26 @@
+package com.sns.homeconnect_v2.domain.usecase.iot_device.sharing
+
+import com.sns.homeconnect_v2.domain.repository.SharedRepository
+import javax.inject.Inject
+
+sealed class RevokeResult {
+    object Success : RevokeResult()
+    data class Failure(val httpCode: Int, val message: String?) : RevokeResult()
+}
+
+class RevokeRecipientPermissionUseCase @Inject constructor(
+    private val repo: SharedRepository
+) {
+    suspend operator fun invoke(serial: String): RevokeResult = try {
+        val resp = repo.revokeRecipientPermission(serial)
+
+        if (resp.isSuccessful) {
+            RevokeResult.Success                      // 204
+        } else {
+            val rawMsg = resp.errorBody()?.string()   // chuỗi JSON thô (nếu cần)
+            RevokeResult.Failure(resp.code(), rawMsg) // 404 / 5xx
+        }
+    } catch (e: Exception) {                          // lỗi mạng
+        RevokeResult.Failure(-1, e.localizedMessage)
+    }
+}

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/iot_device/sharing/RevokeRecipientViewModel.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/iot_device/sharing/RevokeRecipientViewModel.kt
@@ -1,0 +1,48 @@
+package com.sns.homeconnect_v2.presentation.viewmodel.iot_device.sharing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sns.homeconnect_v2.domain.usecase.iot_device.sharing.RevokeRecipientPermissionUseCase
+import com.sns.homeconnect_v2.domain.usecase.iot_device.sharing.RevokeResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RevokeRecipientViewModel @Inject constructor(
+    private val revokeUseCase: RevokeRecipientPermissionUseCase
+) : ViewModel() {
+
+    fun reset() {
+        _state.value = UiState.Idle
+    }
+
+    sealed interface UiState {
+        object Idle : UiState
+        object Loading : UiState
+        object Success : UiState
+        data class Error(val message: String) : UiState
+    }
+
+    private val _state = MutableStateFlow<UiState>(UiState.Idle)
+    val state: StateFlow<UiState> = _state
+
+    private val _snack = Channel<String>()
+    val snack = _snack.receiveAsFlow()
+
+    fun revoke(serial: String) = viewModelScope.launch {
+        _state.value = UiState.Loading
+        when (val res = revokeUseCase(serial)) {
+            is RevokeResult.Success -> _state.value = UiState.Success
+            is RevokeResult.Failure -> {
+                val msg = res.message ?: "Lỗi ${res.httpCode}"
+                _state.value = UiState.Error(msg)
+                _snack.send(msg)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces the functionality to revoke a recipient's permission for a shared device.

Key changes:
- **API Integration:**
    - Added `revokeRecipientPermission` endpoint to `ApiService.kt`.
    - Implemented `revokeRecipientPermission` in `SharedRepositoryImpl.kt` to call the new API endpoint.
- **Domain Layer:**
    - Created `RevokeRecipientPermissionUseCase.kt` to handle the business logic for revoking permission.
    - Defined `RevokeResult` sealed class to represent the outcome of the revocation operation (Success, Failure).
- **ViewModel:**
    - Created `RevokeRecipientViewModel.kt` to manage the UI state (Idle, Loading, Success, Error) and handle the revocation process.
    - It exposes a `state` Flow for observing UI updates and a `snack` Channel for displaying messages.
    - Added a `reset()` function to return the state to Idle.
- **UI (ListDeviceScreen.kt):**
    - Integrated `RevokeRecipientViewModel` into `ListDeviceScreen.kt`.
    - The "delete" action on a shared device item now calls `revokeVM.revoke(device.device_serial)`.
    - Added a `LaunchedEffect` to observe `revokeState`. If revocation is successful, the list of shared devices is refreshed.