### PR TITLE
feat(auth): Implement logout for current and all devices

### DIFF
--- a/app/src/main/java/com/sns/homeconnect_v2/data/AuthManager.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/AuthManager.kt
@@ -28,6 +28,18 @@ class AuthManager @Inject constructor(
     // ✅ THÊM MỚI — dùng cho socket (accountId)
     fun saveAccountId(accountId: String) = prefs.edit().putString("ACCOUNT_ID", accountId).apply()
     fun getAccountId(): String = prefs.getString("ACCOUNT_ID", "") ?: ""
+    fun clearRefreshToken()    = prefs.edit().remove("JWT_TOKEN_REFRESH").apply()
+
+    // 2️⃣ Thiết bị & tài khoản ---------------------------------------------------
+    fun clearDeviceUuid()      = prefs.edit().remove("JWT_TOKEN_DEVICE_UUID").apply()
+    fun clearAccountId()       = prefs.edit().remove("ACCOUNT_ID").apply()
+
+    fun saveUserDeviceId(id: Int) = prefs.edit().putInt("USER_DEVICE_ID", id).apply()
+    fun getUserDeviceId(): Int? {
+        val value = prefs.getInt("USER_DEVICE_ID", -1)
+        return if (value != -1) value else null
+    }
+    fun clearUserDeviceId() = prefs.edit().remove("USER_DEVICE_ID").apply()
 }
 
 

--- a/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/data/remote/api/ApiService.kt
@@ -582,6 +582,17 @@ interface ApiService {
         @Header("Authorization") bearer: String   // "Bearer <JWT>"
     ): Response<Unit>
 
+    @POST("auth/logout")
+    suspend fun logout(
+        @Header("Authorization") token: String,
+        @Body request: Map<String, Int> // hoặc LogoutDeviceRequest nếu bạn muốn dùng model
+    )
+
+    @POST("auth/logout/all")
+    suspend fun logoutAllDevices(
+        @Header("Authorization") token: String      // Bearer <JWT>
+    ): Response<Unit>
+
 //    @POST("spaces")
 //    suspend fun createSpace(
 //        @Body body: CreateSpaceRequest,

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/repository/AuthRepository.kt
@@ -10,10 +10,11 @@ import com.sns.homeconnect_v2.data.remote.dto.response.User
 
 interface AuthRepository {
     suspend fun login(username: String, password: String): LoginResponse
-    suspend fun logout()
+    suspend fun logout(): Result<Unit>
     suspend fun register(user: RegisterRequest): RegisterResponse
     suspend fun getInfoProfile(): User
     suspend fun newPassword(email: String, password: String): NewPasswordResponse
     suspend fun checkEmail(email: String): CheckEmailResponse
     suspend fun forgotPassword(email: String, newPassword: String): ForgotPasswordResponse
+    suspend fun logoutAllDevices(): Result<Unit>
 }

--- a/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/auth/LogOutUseCase.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/domain/usecase/auth/LogOutUseCase.kt
@@ -7,8 +7,12 @@ class LogOutUseCase @Inject constructor(
     private val authRepository: AuthRepository,
 ) {
     suspend operator fun invoke(): Result<Unit> {
+        return authRepository.logout()
+    }
+
+    suspend fun logoutAllDevices(): Result<Unit> {
         return try {
-            authRepository.logout()
+            authRepository.logoutAllDevices()
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/navigation/NavigationGraph.kt
@@ -140,7 +140,10 @@ fun NavigationGraph(navController: NavHostController, snackbarViewModel: Snackba
 
             // --- Setting screens ---
             composable(Screens.Settings.route) {
-                SettingsScreen(navController)
+                SettingsScreen(
+                    navController,
+                    snackbarViewModel = snackbarViewModel
+                )
             }
 
             // --- House screens ---

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/iot_device/FireAlarmDetailScreen.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/screen/iot_device/FireAlarmDetailScreen.kt
@@ -153,7 +153,8 @@ fun FireAlarmDetailScreen(
                 pendingOnError  = null
                 loadingAction   = null
             }
-            else -> {}
+            is UnlinkState.Loading -> { /* optionally show loading */ }
+            is UnlinkState.Idle    -> { /* optionally do nothing */ }
         }
     }
 
@@ -659,7 +660,7 @@ fun FireAlarmDetailScreen(
                                     )
                                 }
 
-                            if (showBottomSheet.value) {
+                                if (showBottomSheet.value) {
                                 ModalBottomSheet(
                                     onDismissRequest = { showBottomSheet.value = false }
                                 ) {
@@ -667,6 +668,7 @@ fun FireAlarmDetailScreen(
                                         is DeviceDisplayInfoState.Success -> {
                                             val product = (displayState as DeviceDisplayInfoState.Success).product
                                             val category = (displayState as DeviceDisplayInfoState.Success).category
+
                                             Column(
                                                 modifier = Modifier
                                                     .fillMaxWidth()
@@ -759,16 +761,20 @@ fun FireAlarmDetailScreen(
 //                                                            .wrapContentWidth(Alignment.CenterHorizontally)
                                                     )
                                                 }
-                                            is DeviceDisplayInfoState.Loading -> {
-                                                Text("Đang tải thông tin sản phẩm...")
                                             }
-                                            is DeviceDisplayInfoState.Error -> {
-                                                Text("Lỗi: ${(displayState as DeviceDisplayInfoState.Error).error}")
-                                            }
-                                            else -> {}
                                         }
+
+                                        is DeviceDisplayInfoState.Loading -> {
+                                            Text("Đang tải thông tin sản phẩm...")
+                                        }
+                                        is DeviceDisplayInfoState.Error -> {
+                                            Text("Lỗi: ${(displayState as DeviceDisplayInfoState.Error).error}")
+                                        }
+                                        else -> {
                                     }
                                 }
+                                }
+                            }
                             }
                         }
                     }

--- a/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/profile/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/sns/homeconnect_v2/presentation/viewmodel/profile/ProfileScreenViewModel.kt
@@ -15,29 +15,32 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+// Trạng thái đăng xuất
 sealed class ProfileState {
-    data object  Idle : ProfileState()
-    data object   Loading : ProfileState()
+    data object Idle : ProfileState()
+    data object Loading : ProfileState()
     data class Success(val success: Boolean, val message: String) : ProfileState()
     data class Error(val success: Boolean, val message: String) : ProfileState()
 }
 
-sealed class InfoProfileState{
-    data object  Idle :  InfoProfileState()              // Chưa làm gì
-    data object  Loading :  InfoProfileState()            // Đang loading
+// Trạng thái lấy profile
+sealed class InfoProfileState {
+    data object Idle : InfoProfileState()
+    data object Loading : InfoProfileState()
     data class Success(val user: User) : InfoProfileState()
     data class Error(val error: String) : InfoProfileState()
 }
 
-sealed class PutInfoProfileState{
-    data object  Idle :  PutInfoProfileState()              // Chưa làm gì
-    data object  Loading :  PutInfoProfileState()            // Đang loading
+// Trạng thái cập nhật profile
+sealed class PutInfoProfileState {
+    data object Idle : PutInfoProfileState()
+    data object Loading : PutInfoProfileState()
     data class Success(val userResponse: UserResponse) : PutInfoProfileState()
     data class Error(val error: String) : PutInfoProfileState()
 }
 
 @HiltViewModel
-class ProfileScreenViewModel  @Inject constructor(
+class ProfileScreenViewModel @Inject constructor(
     private val logOutUseCase: LogOutUseCase,
     private val getInfoProfileUseCase: GetInfoProfileUseCase,
     private val putInfoProfileUseCase: PutInfoProfileUseCase,
@@ -46,32 +49,49 @@ class ProfileScreenViewModel  @Inject constructor(
     private val _logoutState = MutableStateFlow<ProfileState>(ProfileState.Idle)
     val logoutState = _logoutState.asStateFlow()
 
-    // Handle logout and navigation
+    private val _infoProfileState = MutableStateFlow<InfoProfileState>(InfoProfileState.Idle)
+    val infoProfileState = _infoProfileState.asStateFlow()
+
+    private val _putInfoProfileState = MutableStateFlow<PutInfoProfileState>(PutInfoProfileState.Idle)
+    val putInfoProfileState = _putInfoProfileState.asStateFlow()
+
+    // 🔓 Logout thiết bị hiện tại
     fun logout() {
         viewModelScope.launch {
             _logoutState.value = ProfileState.Loading
             logOutUseCase().fold(
                 onSuccess = {
-                    _logoutState.value = ProfileState.Success(true, "Logout successful")
+                    _logoutState.value = ProfileState.Success(true, "Đăng xuất thành công!")
                 },
                 onFailure = { e ->
-                    _logoutState.value = ProfileState.Error(false, e.message ?: "Logout failed")
+                    _logoutState.value = ProfileState.Error(false, e.message ?: "Đăng xuất thất bại")
                 }
             )
         }
     }
 
-    private val _infoProfileState = MutableStateFlow<InfoProfileState>(InfoProfileState.Idle)
-    val infoProfileState = _infoProfileState.asStateFlow()
+    // 🔓 Logout toàn bộ thiết bị
+    fun logoutAllDevices() {
+        viewModelScope.launch {
+            _logoutState.value = ProfileState.Loading
+            logOutUseCase.logoutAllDevices().fold(
+                onSuccess = {
+                    _logoutState.value = ProfileState.Success(true, "Đăng xuất toàn bộ thiết bị thành công.")
+                },
+                onFailure = { e ->
+                    _logoutState.value = ProfileState.Error(false, e.message ?: "Đăng xuất toàn bộ thiết bị thất bại.")
+                }
+            )
+        }
+    }
 
-    /**
-     * Lấy thông tin profile
-     */
+    // 📄 Lấy thông tin người dùng
     fun getInfoProfile() {
         viewModelScope.launch {
+            _infoProfileState.value = InfoProfileState.Loading
             getInfoProfileUseCase().fold(
                 onSuccess = { response ->
-                    Log.d("ProfileScreenViewModel", "Success: $response")
+                    Log.d("ProfileScreenViewModel", "Profile fetched: $response")
                     _infoProfileState.value = InfoProfileState.Success(response)
                 },
                 onFailure = { e ->
@@ -82,14 +102,13 @@ class ProfileScreenViewModel  @Inject constructor(
         }
     }
 
-    private val _putInfoProfileState = MutableStateFlow<PutInfoProfileState>(PutInfoProfileState.Idle)
-    val putInfoProfileState = _putInfoProfileState.asStateFlow()
-
+    // ✏️ Cập nhật thông tin người dùng
     fun putInfoProfile(userId: Int, user: UserRequest) {
         viewModelScope.launch {
-           putInfoProfileUseCase(userId, user).fold(
+            _putInfoProfileState.value = PutInfoProfileState.Loading
+            putInfoProfileUseCase(userId, user).fold(
                 onSuccess = { response ->
-                    Log.d("ProfileScreenViewModel", "Success: $response")
+                    Log.d("ProfileScreenViewModel", "Update success: $response")
                     _putInfoProfileState.value = PutInfoProfileState.Success(response)
                 },
                 onFailure = { e ->


### PR DESCRIPTION
This commit introduces the functionality to log out from the current device and all associated devices.

**Key Changes:**

-   **`AuthManager.kt`:**
    -   Added `clearRefreshToken()`, `clearDeviceUuid()`, `clearAccountId()`, and `clearUserDeviceId()` methods to remove specific authentication tokens and identifiers from shared preferences.
    -   Added `saveUserDeviceId()` and `getUserDeviceId()` to store and retrieve the `userDeviceId` associated with the current logged-in session.

-   **`ApiService.kt`:**
    -   Added new API endpoints:
        -   `POST auth/logout`: Logs out the current device, requiring `userDeviceId` in the request body.
        -   `POST auth/logout/all`: Logs out from all devices associated with the account.

-   **`AuthRepository.kt` & `AuthRepositoryImpl.kt`:**
    -   `logout()`:
        -   Now returns `Result<Unit>`.
        -   Calls the new `auth/logout` API endpoint, passing the `userDeviceId`.
        -   Clears relevant local tokens and identifiers (JWT, refresh token, device UUID, account ID, user device ID).
    -   `logoutAllDevices()`:
        -   New method that returns `Result<Unit>`.
        -   Calls the new `auth/logout/all` API endpoint.
        -   Clears relevant local tokens and identifiers (JWT, refresh token, device UUID, account ID).

-   **`LogOutUseCase.kt`:**
    -   Updated `invoke()` to reflect the `Result<Unit>` return type of `authRepository.logout()`.
    -   Added `logoutAllDevices()` method to call the corresponding repository function.

-   **`ProfileScreenViewModel.kt`:**
    -   `logoutState` (now `ProfileState`) is updated to handle success and error states for both single device and all-device logout.
    -   `logout()`: Calls `logOutUseCase()` for current device logout.
    -   `logoutAllDevices()`: New method to call `logOutUseCase.logoutAllDevices()`.
    -   State management for fetching and updating profile information remains, with clearer naming for states (`InfoProfileState`, `PutInfoProfileState`).

-   **`SettingsScreen.kt`:**
    -   Two logout options are now presented to the user:
        -   "Đăng xuất" (Logout): Triggers `viewModel.logout()`.
        -   "Đăng xuất toàn bộ thiết bị" (Logout all devices): Triggers `viewModel.logoutAllDevices()`.
    -   A confirmation dialog (`WarningDialog`) is shown before performing either logout action, with appropriate messaging.
    -   Snackbar messages are displayed for successful or failed logout attempts.
    -   Upon successful logout, the user is navigated to the `Welcome` screen and the back stack is cleared.

-   **`NavigationGraph.kt`:**
    -   `SnackbarViewModel` is now passed to `SettingsScreen`.

-   **Minor UI fix in `FireAlarmDetailScreen.kt`:**
    -   Corrected nesting of `ModalBottomSheet` content.
    -   Added handling for `UnlinkState.Loading` and `UnlinkState.Idle` in `LaunchedEffect` for `unlinkState`.